### PR TITLE
Tooltip overflow

### DIFF
--- a/src/components/01-atoms/Tooltip/index.js
+++ b/src/components/01-atoms/Tooltip/index.js
@@ -25,13 +25,18 @@ const Tooltip = ({
   const meetingStartTime = startTime;
   const meetingEndTime = meetingStartTime.clone().add(duration, 'hours');
 
+  const truncatePhrase = (phrase) => {
+    const TITLE_LENGTH = 25;
+    return `${phrase.slice(0, TITLE_LENGTH)} ...`;
+  };
+
   return (<div className={styles.tooltip} style={style}>
     <div style={anchorStyle} className={styles.anchorContainer}>
       <div style={tooltipStyle} className={styles.anchor} />
     </div>
     <div className={styles.content}>
       <p>
-        <strong>{ title.slice(0,25)+' ...' }</strong>
+        <strong>{ truncatePhrase(title) }</strong>
         { meetingStartTime.format('h:mma') } - { meetingEndTime.format('h:mma') }
       </p>
       <p>

--- a/src/components/01-atoms/Tooltip/index.js
+++ b/src/components/01-atoms/Tooltip/index.js
@@ -31,7 +31,7 @@ const Tooltip = ({
     </div>
     <div className={styles.content}>
       <p>
-        <strong>{ title }</strong>
+        <strong>{ title.slice(0,25)+' ...' }</strong>
         { meetingStartTime.format('h:mma') } - { meetingEndTime.format('h:mma') }
       </p>
       <p>


### PR DESCRIPTION
Fixed the meeting title overflow that was occurring in the tooltip. Truncated the title for anything over 25 characters.