### PR TITLE
style app to match zeplin

### DIFF
--- a/src/components/01-atoms/Calendar/DateDisplay/styles.scss
+++ b/src/components/01-atoms/Calendar/DateDisplay/styles.scss
@@ -46,5 +46,5 @@
   font-size: 0.9rem;
   font-weight: 100;
   position: absolute;
-  left: 1rem;
+  left: 2rem;
 }

--- a/src/components/01-atoms/Calendar/styles.scss
+++ b/src/components/01-atoms/Calendar/styles.scss
@@ -1,3 +1,4 @@
 .calendar {
   float: left;
+  padding: 90px 0 0 20px;
 }

--- a/src/components/03-organisms/Agenda/styles.scss
+++ b/src/components/03-organisms/Agenda/styles.scss
@@ -17,7 +17,7 @@
 }
 
 .column:first-of-type {
-  padding-top: 35px;
+  padding: 35px 0 0 35px;
 }
 
 .column:last-of-type {

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -35,18 +35,18 @@ export class DashboardContainer extends React.Component {
   render() {
     return (
       <div className={styles.app}>
-        <div className={styles.user}>
-          <span className={styles.hello}>Hello</span>
-          <span className={styles.name}>
-            { this.props.userName }
-          </span>
-          <span className={styles.divider}>|</span>
-          <span className={styles.logout} onClick={this.props.logout}>Logout</span>
-        </div>
         <div className={styles.container}>
           <div className={styles.leftPane}>
             { this.leftPaneContent() }
             <Messages messages={this.props.messages} />
+          </div>
+          <div className={styles.user}>
+            <span className={styles.hello}>Hello</span>
+            <span className={styles.name}>
+              { this.props.userName }
+            </span>
+            <span className={styles.divider}>|</span>
+            <span className={styles.logout} onClick={this.props.logout}>Logout</span>
           </div>
           <Agenda
             roomMeetings={this.props.rooms}

--- a/src/containers/Dashboard/styles.scss
+++ b/src/containers/Dashboard/styles.scss
@@ -20,7 +20,7 @@
   display: flex;
   justify-content: flex-end;
   padding: 2rem;
-  margin-bottom: 3rem;
+  height: 50px;
   color: white;
   font-weight: 100;
 }


### PR DESCRIPTION
This PR moves the "Hello {user} | Logout" block within the app so that the black calendar area takes up the entire left side, as seen in Zeplin.