### PR TITLE
Use actual authentication from bookit-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build": "kyt build",
     "start": "npm run dev",
     "proto": "kyt proto",
-    "test": "npm run lint && kyt test && npm run test-functional",
+    "test": "npm run lint && kyt test",
     "test-watch": "kyt test -- --watch",
     "test-coverage": "kyt test -- --coverage",
     "test-functional": "./node_modules/.bin/testcafe chrome,firefox ./src/functional-tests --app \"npm start\" --app-init-delay 10000",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -20,6 +20,12 @@ export const loginFailure = createAction(LOGIN_FAILED);
 
 export const logout = createAction(LOGOUT);
 
-export const setClient = createAction(SET_USER);
+export const setClient = createAction(SET_USER, user => ({
+  token: user.token,
+  user: user.name,
+  name: user.name,
+  id: user.id,
+  email: user.name, // FIXME: This is weird.
+}));
 
 export const resetUser = createAction(RESET_USER);

--- a/src/actions/meetingCreate.js
+++ b/src/actions/meetingCreate.js
@@ -6,9 +6,10 @@ import {
   MEETING_CREATE_FAILED,
 } from './actionTypes';
 
-export const meetingCreateStart = createAction(MEETING_CREATE_START, (meeting, room) => ({
+export const meetingCreateStart = createAction(MEETING_CREATE_START, (meeting, room, token) => ({
   meeting,
   room,
+  token,
 }));
 
 export const meetingCreateSucceeded = createAction(MEETING_CREATE_SUCCEEDED);

--- a/src/components/02-molecules/MeetingForm/index.js
+++ b/src/components/02-molecules/MeetingForm/index.js
@@ -15,6 +15,7 @@ const MeetingForm = ({
   handleCancel,
   invalid,
   errors = {},
+  token,
   meeting,
   room,
   validationErrors = {},
@@ -40,7 +41,7 @@ const MeetingForm = ({
       <form
         onSubmit={(event) => {
           event.preventDefault();
-          handleSubmit(meeting, room);
+          handleSubmit(meeting, room, token);
         }}
       >
         <Field floatingLabelFixed floatingLabelText="Event name" name="title" component={TextField} errorText={errors.title} style={meetingTitleStyle} />
@@ -60,6 +61,7 @@ MeetingForm.propTypes = {
   visibleErrorMessages: PropTypes.arrayOf(PropTypes.string),
   handleSubmit: PropTypes.func,
   handleCancel: PropTypes.func,
+  token: PropTypes.string,
   meeting: PropTypes.shape({
     title: PropTypes.string,
     start: PropTypes.date,

--- a/src/components/02-molecules/ReservationList/index.js
+++ b/src/components/02-molecules/ReservationList/index.js
@@ -1,12 +1,12 @@
 import React, { PropTypes } from 'react';
+
 import styles from './styles.scss';
 
-const ReservationList = ({ roomMeetings = [], handleEditClick }) => {
+const ReservationList = ({ user, roomMeetings = [], handleEditClick }) => {
   const meetings = roomMeetings.reduce((result, roomMeeting) => {
-    // TODO: Filter by `isOwnedByUser` once the server serves up the goods.
-    // Also change this in containers/Dashboard
-    const userOwnedMeetings = roomMeeting.meetings
-      .filter(meeting => meeting.owner.name === 'Comes from the session!!!');
+    const userOwnedMeetings = roomMeeting.meetings.filter(
+      meeting => meeting.owner.email === user.email
+    );
     return result.concat(userOwnedMeetings);
   }, []);
 
@@ -33,6 +33,9 @@ const ReservationList = ({ roomMeetings = [], handleEditClick }) => {
 };
 
 ReservationList.propTypes = {
+  user: PropTypes.shape({
+    email: PropTypes.string,
+  }),
   roomMeetings: PropTypes.arrayOf(PropTypes.shape()),
   handleEditClick: PropTypes.func.isRequired,
 };

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -48,6 +48,7 @@ export class DashboardContainer extends React.Component {
             { this.leftPaneContent() }
             <Messages messages={messages} />
             <ReservationList
+              user={user}
               roomMeetings={agenda}
               handleEditClick={this.props.populateMeetingEditForm}
             />
@@ -85,7 +86,7 @@ DashboardContainer.propTypes = {
   logout: PropTypes.func.isRequired,
 };
 
-const mapMeeting = (room, user, requestedMeeting) => {
+const mapMeeting = (room, user, requestedMeeting = {}) => {
   const meetings = room.meetings.map(meeting => {
     const start = moment(meeting.start);
     const end = moment(meeting.end);
@@ -99,10 +100,7 @@ const mapMeeting = (room, user, requestedMeeting) => {
       owner: meeting.owner,
       title: meeting.title,
       room: room.room,
-      // TODO: Change this to reflect actual meeting ownership
-      // See commented line below
-      isOwnedByUser: meeting.owner.name === 'Comes from the session!!!',
-      // isOwnedByUser: meeting.owner && (user.email === meeting.owner.email),
+      isOwnedByUser: meeting.owner && (user.email === meeting.owner.email),
       isSelected: requestedMeeting && meeting.id === requestedMeeting.id,
     };
   });

--- a/src/containers/MeetingForm/index.js
+++ b/src/containers/MeetingForm/index.js
@@ -54,6 +54,7 @@ const getSubmittableMeeting = form => {
 };
 
 const mapStateToProps = state => ({
+  token: state.user.token,
   meeting: getSubmittableMeeting(state.form, state.app.requestedMeeting.room),
   room: state.app.requestedMeeting.room,
   initialValues: mapFormValues(state.app.requestedMeeting),
@@ -64,7 +65,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   handleCancel: () => dispatch(cancelMeetingRequest()),
-  handleSubmit: (meeting, room) => dispatch(meetingCreateStart(meeting, room)),
+  handleSubmit: (meeting, room, token) => dispatch(meetingCreateStart(meeting, room, token)),
   handleDeleteClick: () => dispatch(openCancellationDialog()),
 });
 

--- a/src/functional-tests/tests/login.js
+++ b/src/functional-tests/tests/login.js
@@ -11,8 +11,8 @@ test('Logging in sends you to the dashboard', async t => {
 
   const loginPage = new LoginPage();
   await t
-    .typeText(loginPage.emailInput, 'monksp@monksp.org')
-    .typeText(loginPage.passwordInput, 'foo')
+    .typeText(loginPage.emailInput, 'romans@myews.onmicrosoft.com')
+    .typeText(loginPage.passwordInput, 'enterprise: engage')
     .click(loginPage.submitButton);
 
   // Once we've logged in, we should land on the dashboard.

--- a/src/sagas/meetings.js
+++ b/src/sagas/meetings.js
@@ -24,9 +24,8 @@ export function* fetchMeetings() {
 
 export function* createMeeting(action) {
   try {
-    const meeting = action.payload.meeting;
-    const room = action.payload.room;
-    yield call(api.createMeeting, meeting, room);
+    const { payload: { meeting, room, token } } = action;
+    yield call(api.createMeeting, meeting, room, token);
     yield put(closeMeetingDialog());
     yield put(destroy('meeting-editor'));
     yield put(meetingCreateSucceeded());

--- a/src/sagas/meetings.test.js
+++ b/src/sagas/meetings.test.js
@@ -22,7 +22,8 @@ import {
 describe('Meetings Sagas', () => {
   const meeting = 'foo';
   const room = 'bar';
-  const action = { payload: { meeting, room } };
+  const token = '123456abcde';
+  const action = { payload: { meeting, room, token } };
 
   it('fetches meetings', () => {
     const meetings = [meeting];
@@ -45,7 +46,7 @@ describe('Meetings Sagas', () => {
   it('creates meetings', () => {
     const generator = createMeeting(action);
 
-    expect(generator.next().value).toEqual(call(api.createMeeting, meeting, room));
+    expect(generator.next().value).toEqual(call(api.createMeeting, meeting, room, token));
     expect(generator.next().value).toEqual(put(closeMeetingDialog()));
     expect(generator.next().value).toEqual(put(destroy('meeting-editor')));
     expect(generator.next().value).toEqual(put(meetingCreateSucceeded()));


### PR DESCRIPTION
* Now uses the protected meeting creation endpoint from bookit-server
* Reservations List now shows meetings for the currently logged in user
* Sort of tried to avoid relying on `isOwnedByUser`, since it is a derived property and not pure state

This PR should be accepted once the server-auth branch of bookit-server is merged into its master.