### PR TITLE
Normalize state

### DIFF
--- a/src/actions/meetingsFetch.js
+++ b/src/actions/meetingsFetch.js
@@ -1,4 +1,5 @@
 import { createAction } from 'redux-actions';
+import moment from 'moment';
 
 import {
   MEETINGS_FETCH_START,
@@ -6,9 +7,54 @@ import {
   MEETINGS_FETCH_FAILED,
 } from './actionTypes';
 
-// MEETINGS FETCH
+const normalizeMeetingsResponse = schedule => {
+  const meetingsById = schedule.reduce((roomSchedule, curr) => {
+    const meetings = curr.meetings || [];
+    meetings.forEach(meeting => {
+      const start = moment(meeting.start);
+      const end = moment(meeting.end);
+      const duration = end.diff(start, 'minutes') / 60;
+
+      roomSchedule[meeting.id] = {
+        id: meeting.id,
+        title: meeting.title,
+        start,
+        end,
+        duration,
+        owner: meeting.owner,
+        roomId: curr.room.email,
+        roomName: curr.room.name,
+      };
+    });
+    return roomSchedule;
+  }, {});
+
+  const allMeetingIds = Object.keys(meetingsById);
+
+  const roomsById = allMeetingIds.map(id => meetingsById[id])
+    .reduce((rooms, curr) => {
+      rooms[curr.roomId] = {
+        name: curr.roomName,
+        id: curr.roomId,
+      };
+      return rooms;
+    }, {});
+
+  // `allRoomIds` determines the order of the rooms.
+  const allRoomIds = Object.keys(roomsById).sort();
+
+  return {
+    meetingsById,
+    allMeetingIds,
+    allRoomIds,
+    roomsById,
+  };
+};
+
 export const meetingsFetchStart = createAction(MEETINGS_FETCH_START);
+
 export const meetingsFetchSucceeded =
-  createAction(MEETINGS_FETCH_SUCCEEDED);
+  createAction(MEETINGS_FETCH_SUCCEEDED, normalizeMeetingsResponse);
+
 export const meetingsFetchFailed =
-  createAction(MEETINGS_FETCH_FAILED, message => ({ message }));
+    createAction(MEETINGS_FETCH_FAILED, message => ({ message }));

--- a/src/components/01-atoms/RoomTimelineNames/index.js
+++ b/src/components/01-atoms/RoomTimelineNames/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styles from './styles.scss';
 
-const RoomTimelineNames = agenda => agenda.map(({ room }, index) => (
+const RoomTimelineNames = rooms => rooms.map((room, index) => (
   <p key={index} className={styles.roomName}>{ room.name }</p>
 ));
 

--- a/src/components/01-atoms/Tooltip/TooltipContent.js
+++ b/src/components/01-atoms/Tooltip/TooltipContent.js
@@ -1,28 +1,26 @@
 import React, { PropTypes } from 'react';
 
-const TooltipContent = ({ title, start, end, room, owner, isOwnedByUser, styles, onEditClick }) => (
-  <div className={styles.content}>
-    <p>
-      <strong>{ title }</strong>
-      { start.format('h:mma') } - { end.format('h:mma') }
-    </p>
-    <div className={styles.ownerInfo}>
+const TooltipContent =
+  ({ title, start, end, roomName, owner, isOwnedByUser, styles, onEditClick }) => (
+    <div className={styles.content}>
       <p>
-        <strong>{ room.name } Room</strong>
-        by { isOwnedByUser ? 'me' : owner.name }
+        <strong>{ title }</strong>
+        { start.format('h:mma') } - { end.format('h:mma') }
       </p>
-      {isOwnedByUser ? <div onClick={() => onEditClick()} className={styles.edit}>Edit</div> : '' }
+      <div className={styles.ownerInfo}>
+        <p>
+          <strong>{ roomName } Room</strong> by { isOwnedByUser ? 'me' : owner.name }
+        </p>
+        {isOwnedByUser ? <div onClick={() => onEditClick()} className={styles.edit}>Edit</div> : '' }
+      </div>
     </div>
-  </div>
 );
 
 TooltipContent.propTypes = {
   title: PropTypes.string.isRequired,
   start: PropTypes.shape({}).isRequired,
   end: PropTypes.shape({}).isRequired,
-  room: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-  }),
+  roomName: PropTypes.string.isRequired,
   owner: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }),

--- a/src/components/01-atoms/Tooltip/index.js
+++ b/src/components/01-atoms/Tooltip/index.js
@@ -14,7 +14,7 @@ const Tooltip = props => (
       title={props.title}
       start={props.start}
       end={props.end}
-      room={props.room}
+      roomName={props.roomName}
       owner={props.owner}
       isOwnedByUser={props.isOwnedByUser}
       styles={props.styles}
@@ -27,9 +27,7 @@ Tooltip.propTypes = {
   title: PropTypes.string.isRequired,
   start: PropTypes.shape({}).isRequired,
   end: PropTypes.shape({}).isRequired,
-  room: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-  }),
+  roomName: PropTypes.string.isRequired,
   owner: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }),

--- a/src/components/02-molecules/Meeting/index.js
+++ b/src/components/02-molecules/Meeting/index.js
@@ -138,7 +138,7 @@ class MeetingContainer extends React.Component {
 MeetingContainer.propTypes = {
   meeting: PropTypes.shape({ isOwnedByUser: PropTypes.bool }).isRequired,
   onEditClick: PropTypes.func.isRequired,
-  requestedMeetingId: PropTypes.string.isRequired,
+  requestedMeetingId: PropTypes.string,
 };
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/02-molecules/ReservationList/index.js
+++ b/src/components/02-molecules/ReservationList/index.js
@@ -1,43 +1,47 @@
 import React, { PropTypes } from 'react';
+import momentPropTypes from 'react-moment-proptypes';
 
 import styles from './styles.scss';
 
-const ReservationList = ({ user, roomMeetings = [], handleEditClick }) => {
-  const meetings = roomMeetings.reduce((result, roomMeeting) => {
-    const userOwnedMeetings = roomMeeting.meetings.filter(
-      meeting => meeting.owner.email === user.email
-    );
-    return result.concat(userOwnedMeetings);
-  }, []);
-
-  return (
-    <div className={styles.reservationList}>
-      <h2 className={styles.header}>{meetings.length > 0 ? 'My Reservations' : ''}</h2>
-      {meetings.map(meeting => (
-        <div className={styles.meeting} key={meeting.id}>
-          <div className={styles.info}>
-            <div className={styles.title}>{meeting.title}</div>
-            <div className={styles.time}>{meeting.start.format('h:mma')} - {meeting.end.format('h:mma')}</div>
-            <div className={styles.room}>{`${meeting.room.name} Room`}</div>
-          </div>
-          <div
-            onClick={() => {
-              handleEditClick(meeting);
-            }}
-            className={styles.button}
-          >Edit</div>
+const ReservationList = ({ meetings = [], handleEditClick }) => (
+  <div className={styles.reservationList}>
+    <h2 className={styles.header}>{meetings.length > 0 ? 'My Reservations' : ''}</h2>
+    {meetings.map(meeting => (
+      <div className={styles.meeting} key={meeting.id}>
+        <div className={styles.info}>
+          <div className={styles.title}>{meeting.title}</div>
+          <div className={styles.time}>{meeting.start.format('h:mma')} - {meeting.end.format('h:mma')}</div>
+          <div className={styles.room}>{`${meeting.roomName} Room`}</div>
         </div>
-      ))}
-    </div>
-  );
-};
+        <div
+          onClick={() => {
+            handleEditClick(meeting);
+          }}
+          className={styles.button}
+        >Edit</div>
+      </div>
+    ))}
+  </div>
+);
 
 ReservationList.propTypes = {
-  user: PropTypes.shape({
-    email: PropTypes.string,
-  }),
-  roomMeetings: PropTypes.arrayOf(PropTypes.shape()),
   handleEditClick: PropTypes.func.isRequired,
+  meetings: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      start: momentPropTypes.momentObj.isRequired,
+      end: momentPropTypes.momentObj.isRequired,
+      duration: PropTypes.number.isRequired,
+      isOwnedByUser: PropTypes.bool.isRequired,
+      owner: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        email: PropTypes.string.isRequired,
+      }).isRequired,
+      roomName: PropTypes.string.isRequired,
+      roomId: PropTypes.string.isRequired,
+    })
+  ).isRequired,
 };
 
 export default ReservationList;

--- a/src/components/02-molecules/RoomTimeline/index.js
+++ b/src/components/02-molecules/RoomTimeline/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import momentPropTypes from 'react-moment-proptypes';
 
 import { HOUR_WIDTH } from '../../../utils/calculateMeetingOffset';
 
@@ -34,7 +35,20 @@ RoomTimeline.propTypes = {
     name: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
   }).isRequired,
-  meetings: PropTypes.arrayOf(PropTypes.object).isRequired,
+  meetings: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    start: momentPropTypes.momentObj.isRequired,
+    end: momentPropTypes.momentObj.isRequired,
+    duration: PropTypes.number.isRequired,
+    isOwnedByUser: PropTypes.bool.isRequired,
+    owner: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      email: PropTypes.string.isRequired,
+    }).isRequired,
+    roomName: PropTypes.string.isRequired,
+    roomId: PropTypes.string.isRequired,
+  })).isRequired,
   populateMeetingCreateForm: PropTypes.func.isRequired,
 };
 

--- a/src/components/03-organisms/Agenda/index.js
+++ b/src/components/03-organisms/Agenda/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import momentPropTypes from 'react-moment-proptypes';
 
 import roomTimelineNames from '../../01-atoms/RoomTimelineNames';
 import timelineLabelList from '../../01-atoms/TimelineLabelList';
@@ -8,38 +9,55 @@ import RoomTimeline from '../../02-molecules/RoomTimeline';
 
 import styles from './styles.scss';
 
-const renderRoomTimelines = (agenda, populateMeetingCreateForm) => agenda.map(
-  ({ room, meetings }) => (
-    <RoomTimeline
-      key={room.name}
-      meetings={meetings}
-      room={room}
-      populateMeetingCreateForm={populateMeetingCreateForm}
-    />
-  )
-);
+const renderRoomTimelines = (rooms, meetings, populateMeetingCreateForm) => rooms.map((room) => (
+  <RoomTimeline
+    key={room.name}
+    meetings={meetings.filter(meeting => meeting.roomId === room.id)}
+    room={{
+      email: room.id,
+      name: room.name,
+    }}
+    populateMeetingCreateForm={populateMeetingCreateForm}
+  />
+));
 
-const Agenda = ({ agenda = [], populateMeetingCreateForm }) => (
+const Agenda = ({ meetings = [], rooms = [], populateMeetingCreateForm }) => (
   <div className={styles.agenda}>
     <div className={styles.column}>
-      { roomTimelineNames(agenda) }
+      { roomTimelineNames(rooms) }
     </div>
     <div className={[styles.column, styles.timeline].join(' ')} id="timelines">
       { timelineLabelList() }
-      { renderRoomTimelines(agenda, populateMeetingCreateForm) }
+      { renderRoomTimelines(rooms, meetings, populateMeetingCreateForm) }
       { currentTimeIndicator() }
     </div>
   </div>
   );
 
 Agenda.propTypes = {
-  agenda: PropTypes.arrayOf(PropTypes.shape({
-    room: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-    }).isRequired,
-    meetings: PropTypes.arrayOf(PropTypes.object).isRequired,
-  })),
   populateMeetingCreateForm: PropTypes.func.isRequired,
+  meetings: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      start: momentPropTypes.momentObj.isRequired,
+      end: momentPropTypes.momentObj.isRequired,
+      duration: PropTypes.number.isRequired,
+      isOwnedByUser: PropTypes.bool.isRequired,
+      owner: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        email: PropTypes.string.isRequired,
+      }).isRequired,
+      roomName: PropTypes.string.isRequired,
+      roomId: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  rooms: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
+    }).isRequired
+  ).isRequired,
 };
 
 export default Agenda;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -23,7 +23,10 @@ const initialState = {
   messages: [],
   requestedMeeting: {},
   selectedDate: moment().startOf('day'),
-  meetings: [],
+  meetingsById: {},
+  allMeetingIds: [],
+  roomsById: {},
+  allRoomIds: [],
   isCreatingMeeting: false,
   isEditingMeeting: false,
   isCancellingMeeting: false,
@@ -34,24 +37,19 @@ const initialState = {
   },
 };
 
-const mapMeeting = m => {
-  const start = moment(m.start);
-  const end = moment(m.end);
-  return ({ ...m, start, end });
-};
-
-const mapMeetingRoomMeetings = roomMeetings => roomMeetings.map(roomMeeting => (
-  { room: roomMeeting.room,
-    meetings: roomMeeting.meetings ? roomMeeting.meetings.map(mapMeeting) : [],
-  }));
-
 const app = (state = initialState, action) => {
   switch (action.type) {
     case RESET_UI: {
       return { ...state, meetings: [], messages: [] };
     }
     case MEETINGS_FETCH_SUCCEEDED: {
-      return { ...state, meetings: mapMeetingRoomMeetings(action.payload) };
+      return {
+        ...state,
+        meetingsById: action.payload.meetingsById,
+        allMeetingIds: action.payload.allMeetingIds,
+        roomsById: action.payload.roomsById,
+        allRoomIds: action.payload.allRoomIds,
+      };
     }
     case OPEN_CANCELLATION_DIALOG: {
       return {
@@ -75,8 +73,12 @@ const app = (state = initialState, action) => {
       };
     }
     case POPULATE_MEETING_CREATE_FORM: {
-      const meetings = state.meetings
-        .find(rm => rm.room.email === action.payload.room.email).meetings;
+      const meetings = state.allMeetingIds
+        .map(id => state.meetingsById[id])
+        .filter(meeting => meeting.roomId === action.payload.room.email);
+
+      // const meetings = Object.values(state.meetingsById)
+      //   .filter(meeting => meeting.roomId === action.payload.room.email);
       const moment2 = state.selectedDate.clone().add(action.payload.meeting, 'hours');
       const roundedDate = moment2.minutes(Math.floor(state.selectedDate.minutes() / 30) * 30);
       const validatedSlot = getAvailableTimeSlot(roundedDate, meetings);
@@ -94,7 +96,7 @@ const app = (state = initialState, action) => {
         title: action.payload.meeting.title,
         start: moment(action.payload.meeting.start),
         end: moment(action.payload.meeting.end),
-        room: action.payload.meeting.room,
+        roomId: action.payload.meeting.roomId,
         id: action.payload.meeting.id,
       };
       return { ...state, isEditingMeeting: true, requestedMeeting: meeting };

--- a/src/sagas/meetings.js
+++ b/src/sagas/meetings.js
@@ -41,8 +41,7 @@ export function* createMeeting(action) {
 export function* cancelMeeting(action) {
   try {
     const meeting = action.payload.meeting;
-    const room = action.payload.room;
-    yield call(api.cancelMeeting, meeting.id, room.email);
+    yield call(api.cancelMeeting, meeting.id, meeting.roomId);
     yield put(cancelMeetingSucceeded());
     yield put(meetingsFetchStart());
   } catch (err) {


### PR DESCRIPTION
The meetings data as received from the server is deeply nested, which has caused our components to perform all sorts of weird contortions. The reducer logic was overly complex, not to mention the weird mappings and reductions we had going on in several components.
    
This commit flattens the meeting data. Hopefully this will make the application state much easier to work with. The logic for retrieving or updating a given item is now fairly simple and consistent. For instance, given a meeting's ID, we can directly look it up and figure out which room it's in a couple simple steps, without having to dig through other objects to do so. No more `roomMeeting.room.meeting.room`!
    
Here's how the Actions, Containers, and Dumb Components work together under this scheme:
    
## Actions
The application state is flattened in the Action that receives the fetched meetings.
    
## Containers
Also known as "connected components". This is where the Redux store enters the app. `mapStateToProps` is used to modify parts of the state tree in ways specifically catered to the components it contains. Things like `isOwnedByUser` are defined at this level. This is also the place to filter the list of meetings, by, for instance, the date of the meeting.
    
## Dumb Components
There is little, if any manipulation of data in the components themselves. They are responsible for simply rendering the data they are given. Dumb Components are concerned with things like semantic markup and style.

## Resources
See the Redux docs on [normalizing state shape](http://redux.js.org/docs/recipes/reducers/NormalizingStateShape.html). Most of this work was based on ideas I got from reading this section.