### PR TITLE
Restructure the Dashboard component

### DIFF
--- a/src/components/01-atoms/Calendar/index.js
+++ b/src/components/01-atoms/Calendar/index.js
@@ -39,9 +39,13 @@ Calendar.propTypes = {
   handleForwardClick: PropTypes.func.isRequired,
 };
 
+const mapStateToProps = state => ({
+  selectedDate: state.app.selectedDate,
+});
+
 const mapDispatchToProps = dispatch => ({
   handleForwardClick: date => () => dispatch(selectDate(forwardDate(date))),
   handleBackClick: date => () => dispatch(selectDate(backDate(date))),
 });
 
-export default connect(null, mapDispatchToProps)(Calendar);
+export default connect(mapStateToProps, mapDispatchToProps)(Calendar);

--- a/src/components/02-molecules/Header/index.js
+++ b/src/components/02-molecules/Header/index.js
@@ -1,0 +1,21 @@
+import React, { PropTypes } from 'react';
+import styles from './styles.scss';
+
+const Header = ({ user, logout }) => (
+  <header className={styles.header}>
+    <span className={styles.hello}>Hello</span>
+    <span className={styles.name}>
+      { user.name }!
+    </span>
+    <span className={styles.logout} onClick={logout}>Log Out</span>
+  </header>
+);
+
+Header.propTypes = {
+  user: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }),
+  logout: PropTypes.func.isRequired,
+};
+
+export default Header;

--- a/src/components/02-molecules/Header/styles.scss
+++ b/src/components/02-molecules/Header/styles.scss
@@ -1,0 +1,31 @@
+@import '../../../shared-styles/bookit';
+
+.header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 2rem;
+  height: 50px;
+  color: white;
+  font-weight: 100;
+}
+
+.hello {
+  color: $veryyellow;
+  font-weight: 600;
+  margin-right: 5pt;
+}
+
+.name {
+  margin-right: 1rem;
+  text-transform: capitalize;
+}
+
+.logout {
+  color: $slategrey;
+  cursor: pointer;
+  font-weight: 600;
+
+  &:hover {
+    color: $veryyellow;
+  }
+}

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -1,18 +1,11 @@
 import React, { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
 import { connect } from 'react-redux';
-
+import InfoPanel from '../InfoPanel';
 import Agenda from '../../components/03-organisms/Agenda';
-import Calendar from '../../components/01-atoms/Calendar';
-import Messages from '../../components/02-molecules/Messages';
-import ReservationList from '../../components/02-molecules/ReservationList';
-
-import MeetingCancel from '../../components/02-molecules/MeetingCancel';
-import MeetingForm from '../MeetingForm';
-
-import styles from './styles.scss';
-
+import Header from '../../components/02-molecules/Header';
 import isMeetingOnDate from '../../utils/isMeetingOnDate';
+import styles from './styles.scss';
 
 import {
   meetingsFetchStart,
@@ -29,45 +22,25 @@ export class DashboardContainer extends React.Component {
     this.props.requestRooms();
   }
 
-  leftPaneContent() {
-    if (this.props.isEditingMeeting) { return <MeetingForm />; }
-    if (this.props.isCreatingMeeting) { return <MeetingForm />; }
-    if (this.props.isCancellingMeeting) { return (<MeetingCancel />); }
-    return (<Calendar selectedDate={this.props.selectedDate} />);
-  }
-
   render() {
     const {
-      messages,
       user,
       meetings,
       rooms,
+      onLogoutClick,
     } = this.props;
+
     return (
-      <div className={styles.app}>
-        <div className={styles.container}>
-          <div className={styles.leftPane}>
-            { this.leftPaneContent() }
-            <Messages messages={messages} />
-            <ReservationList
-              user={user}
-              meetings={meetings.filter(meeting => meeting.isOwnedByUser)}
-              handleEditClick={this.props.populateMeetingEditForm}
-            />
-          </div>
-          <div className={styles.user}>
-            <span className={styles.hello}>Hello</span>
-            <span className={styles.name}>
-              { user.name }!
-            </span>
-            <span className={styles.logout} onClick={this.props.logout}>Log Out</span>
-          </div>
+      <div className={styles.dashboard}>
+        <InfoPanel />
+        <main>
+          <Header user={user} logout={onLogoutClick} />
           <Agenda
             meetings={meetings}
             rooms={rooms}
             populateMeetingCreateForm={this.props.populateMeetingCreateForm}
           />
-        </div>
+        </main>
       </div>
     );
   }
@@ -77,15 +50,9 @@ DashboardContainer.propTypes = {
   user: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }),
-  isEditingMeeting: PropTypes.bool,
-  isCreatingMeeting: PropTypes.bool.isRequired,
-  isCancellingMeeting: PropTypes.bool,
-  selectedDate: PropTypes.shape({}).isRequired,
-  messages: PropTypes.arrayOf(PropTypes.string),
   requestRooms: PropTypes.func,
   populateMeetingCreateForm: PropTypes.func.isRequired,
-  populateMeetingEditForm: PropTypes.func.isRequired,
-  logout: PropTypes.func.isRequired,
+  onLogoutClick: PropTypes.func.isRequired,
   meetings: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -161,7 +128,7 @@ const mapDispatchToProps = dispatch => ({
   populateMeetingEditForm: meeting => {
     dispatch(populateMeetingEditForm(meeting));
   },
-  logout: () => {
+  onLogoutClick: () => {
     dispatch(logout());
   },
 });

--- a/src/containers/Dashboard/styles.scss
+++ b/src/containers/Dashboard/styles.scss
@@ -1,48 +1,14 @@
 @import '../../shared-styles/bookit';
 
-.app {
+.dashboard {
+  display: flex;
   background-color: $darkblue;
   margin: 0;
   padding: 0;
   height: 100vh;
 }
 
-.leftPane {
-  width: 325px;
-  height: 100vh;
-  float: left;
-  background: $blackish;
+main {
   display: flex;
   flex-direction: column;
-  padding: 70px 30px 30px 20px;
-}
-
-.user {
-  display: flex;
-  justify-content: flex-end;
-  padding: 2rem;
-  height: 50px;
-  color: white;
-  font-weight: 100;
-}
-
-.hello {
-  color: $veryyellow;
-  font-weight: 600;
-  margin-right: 5pt;
-}
-
-.name {
-  margin-right: 1rem;
-  text-transform: capitalize;
-}
-
-.logout {
-  color: $slategrey;
-  cursor: pointer;
-  font-weight: 600;
-
-  &:hover {
-    color: $veryyellow;
-  }
 }

--- a/src/containers/InfoPanel/index.js
+++ b/src/containers/InfoPanel/index.js
@@ -1,0 +1,97 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import momentPropTypes from 'react-moment-proptypes';
+import {
+  populateMeetingEditForm,
+ } from '../../actions';
+import styles from './styles.scss';
+import Calendar from '../../components/01-atoms/Calendar';
+import Messages from '../../components/02-molecules/Messages';
+import ReservationList from '../../components/02-molecules/ReservationList';
+import MeetingCancel from '../../components/02-molecules/MeetingCancel';
+import MeetingForm from '../MeetingForm';
+import isMeetingOnDate from '../../utils/isMeetingOnDate';
+
+const InfoPanel = ({
+  messages,
+  meetings,
+  user,
+  handleReservationEditClick,
+  isEditingMeeting,
+  isCancellingMeeting,
+  isCreatingMeeting }) => {
+  let content = [
+    <Calendar />,
+    <ReservationList
+      user={user}
+      meetings={meetings.filter(meeting => meeting.isOwnedByUser)}
+      handleEditClick={handleReservationEditClick}
+    />,
+  ];
+
+  if (isEditingMeeting || isCreatingMeeting) {
+    content = [<MeetingForm />];
+  }
+  if (isCancellingMeeting) {
+    content = [<MeetingCancel />];
+  }
+  content.push(<Messages messages={messages} />);
+
+  return (
+    <div className={styles.infoPanel}>
+      { content }
+    </div>
+); };
+
+const mapStateToProps = state => {
+  const { allMeetingIds, meetingsById, selectedDate } = state.app;
+
+  const meetings = allMeetingIds
+    .map(id => meetingsById[id])
+    .filter(meeting => isMeetingOnDate(meeting, selectedDate))
+    .filter(meeting => meeting.owner.email === state.user.email);
+
+  return ({
+    messages: state.app.messages,
+    meetings,
+    user: state.app.user,
+    isEditingMeeting: state.app.isEditingMeeting,
+    isCancellingMeeting: state.app.isCancellingMeeting,
+    isCreatingMeeting: state.app.isCreatingMeeting,
+  });
+};
+
+const mapDispatchToProps = dispatch => ({
+  handleReservationEditClick: meeting => {
+    dispatch(populateMeetingEditForm(meeting));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(InfoPanel);
+
+InfoPanel.propTypes = {
+  user: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }),
+  isEditingMeeting: PropTypes.bool,
+  isCreatingMeeting: PropTypes.bool.isRequired,
+  isCancellingMeeting: PropTypes.bool,
+  messages: PropTypes.arrayOf(PropTypes.string),
+  handleReservationEditClick: PropTypes.func.isRequired,
+  meetings: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      start: momentPropTypes.momentObj.isRequired,
+      end: momentPropTypes.momentObj.isRequired,
+      duration: PropTypes.number.isRequired,
+      isOwnedByUser: PropTypes.bool.isRequired,
+      owner: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        email: PropTypes.string.isRequired,
+      }).isRequired,
+      roomName: PropTypes.string.isRequired,
+      roomId: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+};

--- a/src/containers/InfoPanel/styles.scss
+++ b/src/containers/InfoPanel/styles.scss
@@ -1,0 +1,9 @@
+@import '../../shared-styles/bookit';
+
+.infoPanel {
+  flex: 0 0 325px;
+  background: $blackish;
+  display: flex;
+  flex-direction: column;
+  padding: 70px 30px 30px 20px;
+}


### PR DESCRIPTION
The `Dashboard` component was handling a lot of different things at once -- probably too much. This commit creates `Header` and `InfoPanel` components, which are children of `Dashboard`.

This `InfoPanel` is not only badly named, it also serves as a container for the `Calendar`, the `ReservationList`, and the various forms that appear on the left.