### PR TITLE
Style cleanup for left pane, tooltip content, and header

### DIFF
--- a/src/components/01-atoms/Button/styles.scss
+++ b/src/components/01-atoms/Button/styles.scss
@@ -10,5 +10,6 @@
   display: block;
   width: 100%;
   padding: 12px;
-  font-weight: 600;
+  padding-bottom: 10px;
+  font-weight: 500;
 }

--- a/src/components/01-atoms/Calendar/Day/index.js
+++ b/src/components/01-atoms/Calendar/Day/index.js
@@ -24,7 +24,7 @@ const Day = ({ day, handleClick }) => {
     dayStyle.opacity = '0';
   }
   // Not sure what it's for, but it's in the design.
-  if (day.hasLineUnderneath) {
+  if (day.isToday) {
     numberStyle.borderBottom = '2px solid white';
   }
   if (day.hasUserOwnedMeeting) {

--- a/src/components/01-atoms/Calendar/Day/styles.scss
+++ b/src/components/01-atoms/Calendar/Day/styles.scss
@@ -14,6 +14,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  line-height: 0;
 }
 
 .dot {

--- a/src/components/01-atoms/Tooltip/TooltipContent.js
+++ b/src/components/01-atoms/Tooltip/TooltipContent.js
@@ -4,12 +4,13 @@ const TooltipContent =
   ({ title, start, end, roomName, owner, isOwnedByUser, styles, onEditClick }) => (
     <div className={styles.content}>
       <p>
-        <strong>{ title }</strong>
-        { start.format('h:mma') } - { end.format('h:mma') }
+        <strong className={styles.title}>{ title }</strong>
+        <p>{ start.format('h:mma') } - { end.format('h:mma') }</p>
       </p>
       <div className={styles.ownerInfo}>
         <p>
-          <strong>{ roomName } Room</strong> by { isOwnedByUser ? 'me' : owner.name }
+          <strong className={styles.roomTitle}>{ roomName } Room</strong>
+          <p>by { isOwnedByUser ? 'me' : owner.name }</p>
         </p>
         {isOwnedByUser ? <div onClick={() => onEditClick()} className={styles.edit}>Edit</div> : '' }
       </div>

--- a/src/components/02-molecules/Meeting/styles.scss
+++ b/src/components/02-molecules/Meeting/styles.scss
@@ -93,7 +93,9 @@
     }
 
     .edit {
-      color: $veryyellow;
+      cursor: pointer;
+      font-weight: 100;
+      font-size: 14px;
     }
 
     .content {

--- a/src/components/02-molecules/ReservationList/styles.scss
+++ b/src/components/02-molecules/ReservationList/styles.scss
@@ -42,6 +42,7 @@
 }
 
 .button {
-  font-size: 20px;
+  font-size: 16px;
   font-weight: 100;
+  cursor: pointer;
 }

--- a/src/containers/Dashboard/styles.scss
+++ b/src/containers/Dashboard/styles.scss
@@ -28,7 +28,7 @@
 
 .hello {
   color: $veryyellow;
-  font-weight: 600;
+  font-weight: 400;
   margin-right: 5pt;
 }
 
@@ -40,7 +40,7 @@
 .logout {
   color: $slategrey;
   cursor: pointer;
-  font-weight: 600;
+  font-weight: 400;
 
   &:hover {
     color: $veryyellow;

--- a/src/utils/calendar/index.js
+++ b/src/utils/calendar/index.js
@@ -14,6 +14,7 @@ const calendar = selectedDate => {
         date: todaysDate,
         isSelectedDate: todaysDate.isSame(selectedDate, 'day'),
         isInCurrentMonth: todaysDate.isSame(selectedDate, 'month'),
+        isToday: todaysDate.isSame(new Date(), 'day'),
       });
       date.add(1, 'day');
     }


### PR DESCRIPTION
Bookit needed some style cleanup, mostly in the left "info pane," but also in some other areas where changes got lost in the shuffle.

This PR updates some of the styles in the "edit" form (namely the button font and padding), "my reservations" (font sizes, cursor), the header (font weight), and re-implements some of the styles in the tooltip content which were lost after a dev-design pairing session with Lawrence.

This also implements the underline for the current date on the calendar.