### PR TITLE
Add functional test step to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ node_js:
 - '7'
 
 script:
-- npm run lint
-- npm test
-- npm run build
+- yarn lint
+- yarn test
+- yarn build
+- docker pull builditdigital/bookit-server:latest
+- docker run -d -p 8888:8888 builditdigital/bookit-server:latest
+- docker build . -t builditdigital/bookit-web:test
+- docker run -d -p 3001:80 -e API_BASE_URL=http://localhost:8888 builditdigital/bookit-web:test
+- sleep 10; yarn test:functional
 - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
     export IMG_VERSION=`node -p -e "require('./package.json').version"`;
     echo "Building $IMG_VERSION";

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test:unit": "jest",
     "test:unit:coverage": "jest --coverage",
     "test:unit:watch": "jest --watch",
-    "test:functional": "testcafe chrome ./src/functional-tests --app \"npm run dev\" --app-init-delay 10000"
+    "test:functional": "testcafe chrome ./src/functional-tests"
   },
   "jest": {
     "moduleNameMapper": {

--- a/src/functional-tests/tests/login.js
+++ b/src/functional-tests/tests/login.js
@@ -11,8 +11,8 @@ test('Logging in sends you to the dashboard', async (t) => {
 
   const loginPage = new LoginPage()
   await t
-    .typeText(loginPage.emailInput, 'romans@myews.onmicrosoft.com')
-    .typeText(loginPage.passwordInput, 'enterprise: engage')
+    .typeText(loginPage.emailInput, 'z')
+    .typeText(loginPage.passwordInput, 'z')
     .click(loginPage.submitButton)
 
   // Once we've logged in, we should land on the dashboard.


### PR DESCRIPTION
Functional tests should run after the app has been built, they should run against the latest version of the bookit-server, and the test conditions should match the eventual deployed conditions. If the functional tests fail, the Travis build should fail.

This commit accomplishes this: It adds a step to Travis that builds and containerizes the app within the Travis environment. It then pulls the latest container of the bookit server, runs both containers, and then runs the functional tests.

Right now, there is only one test, but this work should allow us to add any other functional tests we like.

Devs can run the functional tests locally just as before: `npm run test:functional`. Hipsters may use `yarn test:functional`.