### PR TITLE
Add more unit tests

### DIFF
--- a/.jestrc.json
+++ b/.jestrc.json
@@ -1,0 +1,27 @@
+{
+  "moduleNameMapper": {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+    "^[./a-zA-Z0-9!&$_-]+\\.(css|scss)$": "identity-obj-proxy"
+  },
+  "testPathIgnorePatterns": [
+    "<rootDir>/(build|docs|node_modules|images)/"
+  ],
+  "testEnvironment": "jsdom",
+  "testRegex": "\\.test.js$",
+  "collectCoverageFrom": [
+    "**/src/**/*.js"
+  ],
+  "coverageReporters": [
+    "text",
+    "lcov",
+    "json"
+  ],
+  "rootDir": ".",
+  "globals": {
+    "window": {}
+  },
+  "setupFiles": [
+    "<rootDir>/__mocks__/storageMock.js"
+  ],
+  "verbose": false
+}

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     ],
     "coverageReporters": [
       "text",
-      "lcov"
+      "lcov",
+      "json",
     ],
     "rootDir": ".",
     "globals": {

--- a/package.json
+++ b/package.json
@@ -95,35 +95,9 @@
     "lint:js": "eslint src/ test/ --cache",
     "lint:style": "stylelint src/**/*.scss src/**/*.css",
     "test": "npm-run-all lint test:unit",
-    "test:unit": "jest",
-    "test:unit:coverage": "jest --coverage",
-    "test:unit:watch": "jest --watch",
+    "test:unit": "jest -c .jestrc.json",
+    "test:unit:watch": "jest -c .jestrc.json --watch",
+    "test:unit:coverage": "jest -c .jestrc.json --coverage",
     "test:functional": "testcafe chrome ./src/functional-tests"
-  },
-  "jest": {
-    "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "^[./a-zA-Z0-9!&$_-]+\\.(css|scss)$": "identity-obj-proxy"
-    },
-    "testPathIgnorePatterns": [
-      "<rootDir>/(build|docs|node_modules|images)/"
-    ],
-    "testEnvironment": "jsdom",
-    "testRegex": "\\.test.js$",
-    "collectCoverageFrom": [
-      "**/src/**/*.js"
-    ],
-    "coverageReporters": [
-      "text",
-      "lcov",
-      "json",
-    ],
-    "rootDir": ".",
-    "globals": {
-      "window": {}
-    },
-    "setupFiles": [
-      "<rootDir>/__mocks__/storageMock.js"
-    ]
   }
 }

--- a/src/components/01-atoms/Link/index.js
+++ b/src/components/01-atoms/Link/index.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// import history from '../../../history'
+
+const isModifiedEvent = event => !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
+
+class Link extends React.Component {
+  static propTypes = {
+    onClick: PropTypes.func,
+    target: PropTypes.string,
+    replace: PropTypes.bool,
+    to: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]).isRequired,
+  };
+
+  static defaultProps = {
+    replace: false,
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+        replace: PropTypes.func.isRequired,
+        createHref: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+  };
+
+  handleClick = (event) => {
+    if (this.props.onClick) {
+      this.props.onClick(event)
+    }
+
+    if (
+      !event.defaultPrevented &&
+      event.button === 0 &&
+      !this.props.target &&
+      !isModifiedEvent(event)
+    ) {
+      event.preventDefault()
+
+      const { history } = this.context.router
+      const { replace, to } = this.props
+
+      if (replace) {
+        history.replace(to)
+      } else {
+        history.push(to)
+      }
+    }
+  }
+
+  render() {
+    const { replace, to, ...props } = this.props  // eslint-disable-line no-unused-vars
+
+    const href = this.context.router.history.createHref(
+      typeof to === 'string' ? { pathName: to } : to
+    )
+
+    return <a {...props} onClick={this.handleClick} href={href} />
+  }
+}
+
+export default Link

--- a/src/components/01-atoms/Link/index.test.js
+++ b/src/components/01-atoms/Link/index.test.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Link from '.'
+
+const context = {
+  router: {
+    history: {
+      push: jest.fn(),
+      replace: jest.fn(),
+      createHref: jest.fn(),
+    },
+  },
+}
+
+const event = {
+  defaultPrevented: false,
+  button: 0,
+  metaKey: false,
+  altKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  preventDefault: jest.fn(),
+}
+
+beforeEach(() => {
+  context.router.history.push.mockClear()
+  context.router.history.replace.mockClear()
+  context.router.history.createHref.mockClear()
+  event.preventDefault.mockClear()
+})
+
+describe('<Link />', () => {
+  it('renders', () => {
+    const wrapper = shallow(<Link to="/nowhere" />, { context })
+    expect(wrapper).toBeTruthy()
+  })
+
+  it('handles history.push through handleClick', () => {
+    const wrapper = shallow(<Link to="/nowhere" />, { context })
+    wrapper.simulate('click', event)
+    expect(context.router.history.push).toHaveBeenCalled()
+  })
+
+  it('uses onClick from props', () => {
+    const mockOnClick = jest.fn()
+    const wrapper = shallow(<Link to="/nowhere" onClick={mockOnClick} />, { context })
+    wrapper.simulate('click', event)
+    expect(mockOnClick).toHaveBeenCalled()
+  })
+
+  it('uses history.replace when passed `replace` in props', () => {
+    const wrapper = shallow(<Link to="/nowhere" replace />, { context })
+    wrapper.simulate('click', event)
+    expect(context.router.history.replace).toHaveBeenCalled()
+  })
+})

--- a/src/components/02-molecules/Header/index.js
+++ b/src/components/02-molecules/Header/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import history from '../../../history'
+import Link from '../../01-atoms/Link'
 
 import styles from './styles.scss'
 
@@ -11,8 +11,8 @@ const Header = ({ user, logout }) => (
     <span className={styles.name}>
       { user.name }!
     </span>
-    <span className={styles.link} onClick={() => history.push('/admin')}>Admin</span>
-    <span className={styles.link} onClick={logout}>Log Out</span>
+    <Link to="/admin" className={styles.link}>Admin</Link>
+    <Link to="/login" className={styles.link} onClick={logout}>Log Out</Link>
   </header>
 )
 

--- a/src/components/02-molecules/Header/index.test.js
+++ b/src/components/02-molecules/Header/index.test.js
@@ -5,10 +5,6 @@ import Header from '.'
 
 import styles from './styles.scss'
 
-import history from '../../../history'
-
-jest.mock('../../../history')
-
 describe('<Header />', () => {
   const props = {
     user: { name: 'testy mctestface' },
@@ -18,11 +14,5 @@ describe('<Header />', () => {
   it('should welcome the user', () => {
     const wrapper = shallow(<Header {...props} />)
     expect(wrapper.find(`.${styles.name}`).text()).toBe(`${props.user.name}!`)
-  })
-
-  it('should call history.push when the admin link is clicked', () => {
-    const wrapper = shallow(<Header {...props} />)
-    wrapper.find(`.${styles.link}`).first().simulate('click')
-    expect(history.push.mock.calls.length).toBe(1)
   })
 })

--- a/src/components/02-molecules/Header/styles.scss
+++ b/src/components/02-molecules/Header/styles.scss
@@ -25,6 +25,7 @@
   cursor: pointer;
   font-weight: 400;
   margin-right: 1rem;
+  text-decoration: none;
 
   &:hover {
     color: $veryyellow;

--- a/src/components/02-molecules/Meeting/index.js
+++ b/src/components/02-molecules/Meeting/index.js
@@ -12,9 +12,9 @@ import { calculateMeetingOffset } from '../../../utils/calculateMeetingOffset'
 
 import styles from './styles.scss'
 
-const TIMELINE_WIDTH = 1968
+export const TIMELINE_WIDTH = 1968
 
-class MeetingContainer extends React.Component {
+export class Meeting extends React.Component {
   constructor(props) {
     super(props)
 
@@ -136,7 +136,7 @@ class MeetingContainer extends React.Component {
   }
 }
 
-MeetingContainer.propTypes = {
+Meeting.propTypes = {
   meeting: PropTypes.shape({ isOwnedByUser: PropTypes.bool }).isRequired,
   onEditClick: PropTypes.func.isRequired,
   requestedMeetingId: PropTypes.string,
@@ -151,6 +151,6 @@ const mapStateToProps = state => ({
   requestedMeetingId: state.app.requestedMeeting.id,
 })
 
-const connected = connect(mapStateToProps, mapDispatchToProps)(MeetingContainer)
+const connected = connect(mapStateToProps, mapDispatchToProps)(Meeting)
 
 export default connected

--- a/src/components/02-molecules/Meeting/index.test.js
+++ b/src/components/02-molecules/Meeting/index.test.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+
+import moment from 'moment'
+
+import { Meeting, TIMELINE_WIDTH } from '.'
+import TooltipContent from '../../01-atoms/Tooltip/TooltipContent'
+
+// !THIS NEEDS MORE TESTS FOR MEANINGFUL COVERAGE!
+//
+// At this time, all these tests do is show that the Meeting component
+// is perhaps too complex, but to make it any less so would result in
+// problems due to its weird nature.
+
+describe('<Meeting />', () => {
+  const props = {
+    meeting: {
+      id: 'xyz-321',
+      title: 'A Meeting',
+      start: moment(),
+      end: moment().add(1, 'hour'),
+      duration: moment().add(1, 'hour').diff(moment(), 'minutes') / 60,
+      roomName: 'roomy mcroomface',
+      owner: {
+        name: 'some guy',
+      },
+      isOwnedByUser: true,
+    },
+    onEditClick: jest.fn(),
+    requestedMeetingId: 'xyz-123',
+  }
+
+  it('renders itself and its child <Tooltip /> using already in-place props', () => {
+    const wrapper = mount(<Meeting {...props} />)
+    expect(wrapper).toBeTruthy()
+    expect(props.onEditClick.mock.calls.length).toBe(0)
+    wrapper.find(TooltipContent).first().find('.edit').first().simulate('click')
+    expect(props.onEditClick.mock.calls.length).toBe(1)
+  })
+
+  it('ensures its width is adjusted down when over `TIMELINE_WIDTH`', () => {
+    const start = moment().hour(21)
+    const end = moment().hour(21).add(4, 'hours')
+    const duration = end.diff(start, 'minutes') / 60
+    const meeting = { ...props.meeting, start, end, duration }
+    const propsCopy = { ...props, meeting }
+    const wrapper = shallow(<Meeting {...propsCopy} />)
+    expect(wrapper.prop('style').width).toBeLessThan(TIMELINE_WIDTH)
+  })
+})

--- a/src/components/02-molecules/MeetingCancel/index.js
+++ b/src/components/02-molecules/MeetingCancel/index.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types'
 
 import { connect } from 'react-redux'
 
-import Button from '../../01-atoms/Button/index'
+import Button from '../../01-atoms/Button'
 
 import { closeCancellationDialog, cancelMeetingStart } from '../../../actions'
 
 import styles from './styles.scss'
 
-export class MeetingCancelContainer extends React.Component {
+export class MeetingCancel extends React.Component {
   static propTypes = {
     meeting: PropTypes.shape({
       owner: PropTypes.shape({
@@ -70,6 +70,6 @@ const mapDispatchToProps = dispatch => ({
 const connected = connect(
   mapStateToProps,
   mapDispatchToProps
-)(MeetingCancelContainer)
+)(MeetingCancel)
 
 export default connected

--- a/src/components/02-molecules/MeetingCancel/index.test.js
+++ b/src/components/02-molecules/MeetingCancel/index.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import moment from 'moment'
+
+import Button from '../../01-atoms/Button/index'
+
+import { MeetingCancel } from '.'
+
+describe('<MeetingCancel />', () => {
+  const props = {
+    meeting: {
+      id: 'xyz-321',
+      title: 'A Meeting',
+      start: moment(),
+      end: moment().add(1, 'hour'),
+      duration: moment().add(1, 'hour').diff(moment(), 'minutes') / 60,
+      roomName: 'roomy mcroomface',
+      owner: {
+        name: 'some guy',
+      },
+      isOwnedByUser: true,
+    },
+    room: {
+      name: 'puce',
+      email: 'puce-room@some.com',
+    },
+    closeCancellationDialog: jest.fn(),
+    cancelMeeting: jest.fn(),
+  }
+
+  it('renders ok', () => {
+    const wrapper = shallow(<MeetingCancel {...props} />)
+    expect(wrapper).toBeTruthy()
+  })
+
+  it('responds to click events', () => {
+    const wrapper = shallow(<MeetingCancel {...props} />)
+    const yesButton = wrapper.find(Button).first()
+    const noButton = wrapper.find(Button).last()
+
+    yesButton.simulate('click')
+    expect(props.cancelMeeting.mock.calls.length).toBe(1)
+
+    noButton.simulate('click')
+    expect(props.closeCancellationDialog.mock.calls.length).toBe(1)
+  })
+})

--- a/src/components/02-molecules/MeetingCancel/index.test.js
+++ b/src/components/02-molecules/MeetingCancel/index.test.js
@@ -29,7 +29,7 @@ describe('<MeetingCancel />', () => {
     cancelMeeting: jest.fn(),
   }
 
-  it('renders ok', () => {
+  it('renders', () => {
     const wrapper = shallow(<MeetingCancel {...props} />)
     expect(wrapper).toBeTruthy()
   })

--- a/src/components/02-molecules/Messages/index.test.js
+++ b/src/components/02-molecules/Messages/index.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import Messages from './index'
+import Messages from '.'
+
 import styles from './styles.scss'
 
 describe('Messages Component', () => {

--- a/src/components/02-molecules/RecentlyAddedUsersTable/index.test.js
+++ b/src/components/02-molecules/RecentlyAddedUsersTable/index.test.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import moment from 'moment'
+
+import RecentlyAddedUsersTable from '.'
+import styles from './styles.scss'
+
+describe('<RecentlyAddedUsersTable />', () => {
+  it('renders', () => {
+    const wrapper = shallow(<RecentlyAddedUsersTable />)
+    expect(wrapper).toBeTruthy()
+  })
+
+  it('shows a user added within the current week', () => {
+    const user = {
+      name: 'Testy McTesterson',
+      email: 'test@test.com',
+      location: 'Testerton',
+      team: 'Testing',
+      active: true,
+      dateAdded: moment(),
+    }
+    const wrapper = shallow(<RecentlyAddedUsersTable users={[user, { ...user, dateAdded: moment().subtract(2, 'weeks')}]} />)
+    expect(wrapper.find('tr').length).toBe(1)
+  })
+
+  it('shows a non-active user added within the current week as "Pending"', () => {
+    const user = {
+      name: 'Testy McTesterson',
+      email: 'test@test.com',
+      location: 'Testerton',
+      team: 'Testing',
+      active: false,
+      dateAdded: moment(),
+    }
+    const wrapper = shallow(<RecentlyAddedUsersTable users={[user]} />)
+    expect(wrapper.find(`.${styles.pending}`).text()).toEqual('(Pending)')
+  })
+
+  it('does not show a user that is missing the `dateAdded` "hidden" property', () => {
+    const user = {
+      name: 'Testy McTesterson',
+      email: 'test@test.com',
+      location: 'Testerton',
+      team: 'Testing',
+      active: true,
+    }
+    const wrapper = shallow(<RecentlyAddedUsersTable users={[user]} />)
+    expect(wrapper.find('tr').length).toBe(0)
+  })
+})

--- a/src/components/02-molecules/ReservationList/ReservationItem.js
+++ b/src/components/02-molecules/ReservationList/ReservationItem.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import MomentPropTypes from 'react-moment-proptypes'
+
+const ReservationItem = ({ styles, meeting, onClick }) => (
+  <div className={styles.meeting}>
+    <div className={styles.info}>
+      <div className={styles.title}>
+        {meeting.title}
+      </div>
+      <div className={styles.time}>
+        {meeting.start.format('h:mma')} - {meeting.end.format('h:mma')}
+      </div>
+      <div className={styles.room}>
+        {meeting.roomName} Room
+      </div>
+    </div>
+    {/* THIS SHOULD BE A Button COMPONENT! */}
+    <div onClick={onClick} className={styles.button}>Edit</div>
+  </div>
+)
+
+ReservationItem.propTypes = {
+  styles: PropTypes.object,
+  meeting: PropTypes.shape({
+    title: PropTypes.string,
+    start: MomentPropTypes.momentObj,
+    end: MomentPropTypes.momentObj,
+    roomName: PropTypes.string,
+  }),
+  onClick: PropTypes.func.isRequired,
+}
+
+export default ReservationItem

--- a/src/components/02-molecules/ReservationList/ReservationItem.test.js
+++ b/src/components/02-molecules/ReservationList/ReservationItem.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import moment from 'moment'
+
+import ReservationItem from './ReservationItem'
+import styles from './styles.scss'
+
+describe('<ReservationItem />', () => {
+  const props = {
+    styles,
+    meeting: {
+      id: 'xyz-321',
+      title: 'A Meeting',
+      start: moment(),
+      end: moment().add(1, 'hour'),
+      duration: moment().add(1, 'hour').diff(moment(), 'minutes') / 60,
+      roomName: 'roomy mcroomface',
+      owner: {
+        name: 'some guy',
+        email: 'someguy@test.com',
+      },
+      isOwnedByUser: true,
+      roomId: '1',
+    },
+    onClick: jest.fn(),
+  }
+  it('renders', () => {
+    const wrapper = shallow(<ReservationItem {...props} />)
+    expect(wrapper).toBeTruthy()
+  })
+})

--- a/src/components/02-molecules/ReservationList/index.js
+++ b/src/components/02-molecules/ReservationList/index.js
@@ -42,7 +42,7 @@ ReservationList.propTypes = {
       roomName: PropTypes.string.isRequired,
       roomId: PropTypes.string.isRequired,
     })
-  ).isRequired,
+  ),
 }
 
 export default ReservationList

--- a/src/components/02-molecules/ReservationList/index.js
+++ b/src/components/02-molecules/ReservationList/index.js
@@ -3,25 +3,16 @@ import PropTypes from 'prop-types'
 
 import momentPropTypes from 'react-moment-proptypes'
 
+import ReservationItem from './ReservationItem'
+// import Button from '../../01-atoms/Button'
+
 import styles from './styles.scss'
 
 const ReservationList = ({ meetings = [], handleEditClick }) => (
   <div className={styles.reservationList}>
     <h2 className={styles.header}>{meetings.length > 0 ? 'My Reservations' : ''}</h2>
     {meetings.map(meeting => (
-      <div className={styles.meeting} key={meeting.id}>
-        <div className={styles.info}>
-          <div className={styles.title}>{meeting.title}</div>
-          <div className={styles.time}>{meeting.start.format('h:mma')} - {meeting.end.format('h:mma')}</div>
-          <div className={styles.room}>{`${meeting.roomName} Room`}</div>
-        </div>
-        <div
-          onClick={() => {
-            handleEditClick(meeting)
-          }}
-          className={styles.button}
-        >Edit</div>
-      </div>
+      <ReservationItem key={meeting.id} styles={styles} meeting={meeting} onClick={() => handleEditClick(meeting)} />
     ))}
   </div>
 )

--- a/src/components/02-molecules/ReservationList/index.test.js
+++ b/src/components/02-molecules/ReservationList/index.test.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import moment from 'moment'
+
+import ReservationList from '.'
+import styles from './styles.scss'
+
+describe('<ReservationList />', () => {
+  const props = {
+    handleEditClick: jest.fn(),
+    meetings: [
+      {
+        id: 'xyz-321',
+        title: 'A Meeting',
+        start: moment(),
+        end: moment().add(1, 'hour'),
+        duration: moment().add(1, 'hour').diff(moment(), 'minutes') / 60,
+        roomName: 'roomy mcroomface',
+        owner: {
+          name: 'some guy',
+          email: 'someguy@test.com',
+        },
+        isOwnedByUser: true,
+        roomId: '1',
+      },
+    ],
+  }
+  it('renders', () => {
+    const wrapper = shallow(<ReservationList {...props} />)
+    expect(wrapper).toBeTruthy()
+  })
+
+  it('responds to button clicks', () => {
+    const wrapper = shallow(<ReservationList {...props} />)
+    wrapper.find(`.${styles.button}`).first().simulate('click')
+    expect(props.handleEditClick.mock.calls.length).toBe(1)
+  })
+
+  it('does not show "My Reservations" when there are no meetings passed to the component', () => {
+    const wrapper = shallow(<ReservationList handleEditClick={props.handleEditClick} />)
+    expect(wrapper.find('h2').first().text().length).toBe(0)
+  })
+})

--- a/src/components/02-molecules/ReservationList/index.test.js
+++ b/src/components/02-molecules/ReservationList/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import moment from 'moment'
 
@@ -32,7 +32,7 @@ describe('<ReservationList />', () => {
   })
 
   it('responds to button clicks', () => {
-    const wrapper = shallow(<ReservationList {...props} />)
+    const wrapper = mount(<ReservationList {...props} />)
     wrapper.find(`.${styles.button}`).first().simulate('click')
     expect(props.handleEditClick.mock.calls.length).toBe(1)
   })

--- a/src/components/02-molecules/RoomTimeline/index.test.js
+++ b/src/components/02-molecules/RoomTimeline/index.test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+
+import moment from 'moment'
+
+import RoomTimeline from '.'
+import styles from './styles.scss'
+
+describe('<RoomTimeline />', () => {
+  const props = {
+    room: {
+      name: 'puce',
+      email: 'puce-room@some.com',
+    },
+    meetings: [
+      {
+        id: 'xyz-321',
+        title: 'A Meeting',
+        start: moment(),
+        end: moment().add(1, 'hour'),
+        duration: moment().add(1, 'hour').diff(moment(), 'minutes') / 60,
+        roomName: 'roomy mcroomface',
+        owner: {
+          name: 'some guy',
+          email: 'someguy@test.com',
+        },
+        isOwnedByUser: true,
+        roomId: '1',
+      },
+    ],
+    populateMeetingCreateForm: jest.fn(),
+  }
+
+  it('renders', () => {
+    const wrapper = shallow(<RoomTimeline {...props} />)
+    expect(wrapper).toBeTruthy()
+  })
+
+  it('mounts and sets offsetLeft to 653 (for some reason)', () => {
+    const fakeElement = { scrollLeft: 0 }
+    const propsCopy = { ...props, meetings: [] }
+
+    /* eslint no-unused-vars: 0 */
+    document.getElementById = jest.fn(selector => fakeElement)
+
+    expect(fakeElement.scrollLeft).toEqual(0)
+    mount(<RoomTimeline {...propsCopy} />)
+    expect(fakeElement.scrollLeft).toEqual(653)
+  })
+
+  it('responds to click events', () => {
+    const wrapper = shallow(<RoomTimeline {...props} />)
+    wrapper.find(`.${styles.meetings}`).first().simulate('click', { nativeEvent: { offsetX: 100 } })
+    expect(props.populateMeetingCreateForm.mock.calls.length).toBe(1)
+  })
+})

--- a/src/components/03-organisms/Agenda/index.js
+++ b/src/components/03-organisms/Agenda/index.js
@@ -11,7 +11,7 @@ import RoomTimeline from '../../02-molecules/RoomTimeline'
 
 import styles from './styles.scss'
 
-const renderRoomTimelines = (rooms, meetings, populateMeetingCreateForm) => rooms.map(room => (
+export const renderRoomTimelines = (rooms, meetings, populateMeetingCreateForm) => rooms.map(room => (
   <RoomTimeline
     key={room.name}
     meetings={meetings.filter(meeting => meeting.roomId === room.id)}
@@ -23,7 +23,7 @@ const renderRoomTimelines = (rooms, meetings, populateMeetingCreateForm) => room
   />
 ))
 
-const Agenda = ({ meetings = [], rooms = [], populateMeetingCreateForm }) => (
+const Agenda = ({ meetings, rooms, populateMeetingCreateForm }) => (
   <div className={styles.agenda}>
     <div className={styles.column}>
       { roomTimelineNames(rooms) }

--- a/src/components/03-organisms/Agenda/index.test.js
+++ b/src/components/03-organisms/Agenda/index.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import moment from 'moment'
+
+import RoomTimeline from '../../02-molecules/RoomTimeline'
+
+import Agenda, { renderRoomTimelines } from '.'
+
+describe('<Agenda />', () => {
+  const props = {
+    meetings: [],
+    rooms: [],
+    populateMeetingCreateForm: jest.fn(),
+  }
+  it('renders', () => {
+    const wrapper = shallow(<Agenda {...props} />)
+    expect(wrapper).toBeTruthy()
+  })
+})
+
+// This is so laaaaaaaaaaaaaaaame.
+describe('#renderRoomTimelines()', () => {
+  it('returns an array of <RoomTimeline /> components', () => {
+    const room = { name: 'puce', id: 'puce-room-xyz' }
+    const meeting = {
+      id: 'xyz-321',
+      title: 'A Meeting',
+      start: moment(),
+      end: moment().add(1, 'hour'),
+      duration: moment().add(1, 'hour').diff(moment(), 'minutes') / 60,
+      isOwnedByUser: true,
+      owner: {
+        name: 'some guy',
+        email: 'someguy@some.com',
+      },
+      roomName: room.name,
+      roomId: room.id,
+    }
+    const populateMeetingCreateForm = jest.fn()
+    const result = renderRoomTimelines([room], [meeting], populateMeetingCreateForm)
+    expect(result.length).toBe(1)
+    expect(shallow(<div>{result[0]}</div>).find(RoomTimeline)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Day Three of adding unit tests.

Changes made to source modules are a result of either:

1. Needing to expose a value or function to ensure tests were using correct values without having to just hardcode them into the tests with little to no explanation

2. Requiring fixes due to flaws exposed during testing

Note that when testing components that are `connect`ed to redux, the pattern for unit testing _just_ the component requires us to export the named component, and exporting the connected component as the default (which we were doing anyway).