### PR TITLE
Tidy travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,8 @@ script:
 - yarn lint
 - yarn test:unit
 - yarn build
-- docker pull builditdigital/bookit-server:latest
-- docker run -d -p 8888:8888 builditdigital/bookit-server:latest
-- docker build . -t builditdigital/bookit-web:test
-- docker run -d -p 3001:80 -e API_BASE_URL=http://localhost:8888 builditdigital/bookit-web:test
-- sleep 10; yarn test:functional
-- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
-    export IMG_VERSION=`node -p -e "require('./package.json').version"`;
-    echo "Building $IMG_VERSION";
-    docker build -t builditdigital/bookit-web:$IMG_VERSION .;
-    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    docker push builditdigital/bookit-web:$IMG_VERSION;
-    docker tag builditdigital/bookit-web:$IMG_VERSION builditdigital/bookit-web:latest;
-    docker push builditdigital/bookit-web:latest;
-  fi
+- ./scripts/run-functional-tests.sh
+- ./scripts/push-docker-image.sh
 
 deploy:
   provider: script

--- a/scripts/push-docker-image.sh
+++ b/scripts/push-docker-image.sh
@@ -1,4 +1,4 @@
-!#/bin/bash
+#!/bin/bash
 
 set -ev
 

--- a/scripts/push-docker-image.sh
+++ b/scripts/push-docker-image.sh
@@ -1,0 +1,13 @@
+!#/bin/bash
+
+set -ev
+
+if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
+  export IMG_VERSION=`node -p -e "require('./package.json').version"`
+  echo "Building $IMG_VERSION"
+  docker build -t builditdigital/bookit-web:$IMG_VERSION .
+  docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  docker push builditdigital/bookit-web:$IMG_VERSION
+  docker tag builditdigital/bookit-web:$IMG_VERSION builditdigital/bookit-web:latest
+  docker push builditdigital/bookit-web:latest
+fi

--- a/scripts/run-functional-tests.sh
+++ b/scripts/run-functional-tests.sh
@@ -1,4 +1,4 @@
-!#/bin/bash
+#!/bin/bash
 
 set -ev
 

--- a/scripts/run-functional-tests.sh
+++ b/scripts/run-functional-tests.sh
@@ -1,0 +1,7 @@
+!#/bin/bash
+
+docker pull builditdigital/bookit-server:latest
+docker run -d -p 8888:8888 builditdigital/bookit-server:latest
+docker build . -t builditdigital/bookit-web:test
+docker run -d -p 3001:80 -e API_BASE_URL=http://localhost:8888 builditdigital/bookit-web:test
+sleep 10; yarn test:functional

--- a/scripts/run-functional-tests.sh
+++ b/scripts/run-functional-tests.sh
@@ -1,5 +1,7 @@
 !#/bin/bash
 
+set -ev
+
 docker pull builditdigital/bookit-server:latest
 docker run -d -p 8888:8888 builditdigital/bookit-server:latest
 docker build . -t builditdigital/bookit-web:test


### PR DESCRIPTION
Reason for this is each `script` invocation in travis is ideally meant to be a single pass/fail item.

Our current travis script includes multiple steps (all of which can yes, pass or fail) that are in fact boilerplate to allow for specific test suites and/or build steps to run.

By isolating these boilerplate script items into distinct bash scripts, we reduce the clutter of the `scripts` block and make it clear what we are actually intending to achieve with each script.

For clarification, the `set -ev` call inside each bash script added in this PR ensures that each script echoes each call within said script (the `v` flag) and will fail-fast on _any_ call that failed (the `e` flag) and prevent additionally lines from running (since there's no point running additional steps if a prior one failed).