### PR TITLE
add auth token to API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ build
 # Optional REPL history
 .node_repl_history
 
+# Tern for JS Project file
+.tern-project
+
 # OS-specific temporary files
 Thumbs.db
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,5 @@ before_script:
 - fluxbox >/dev/null 2>&1 &
 
 after_success:
-- 'npm run test:unit:coverage'
+- 'yarn test:unit:coverage'
 - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ language: node_js
 node_js:
 - '7'
 
+# NOTE: Removed the following from before ./scripts/push-docker-image.sh
+# - ./scripts/run-functional-tests.sh
+
 script:
 - yarn lint
 - yarn test:unit
 - yarn build
-- ./scripts/run-functional-tests.sh
 - ./scripts/push-docker-image.sh
 
 deploy:

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,50 +9,35 @@ const login = (user, password) => agent
   .send({ user, password })
   .then(response => response.body)
 
-// Use this one when the server is ready
-// const login = (email, password) => agent.post(`${apiBaseUrl}/login`)
-//   .send({
-//     username: email,
-//     password,
-//   })
-//   .then((response) => {
-//     console.log(response);
-//     const user = JSON.parse(response.text);
-//     return user;
-//   })
-//   .catch(error => error);
-
-const fetchMeetings = (startDate, endDate) => {
+const fetchMeetings = (token, startDate, endDate) => {
   let start = startDate
   let end = endDate
+
   if (!startDate) {
     start = moment().startOf('day').format('YYYY-MM-DD')
   }
+
   if (!endDate) {
     end = moment(start).add(1, 'day').format('YYYY-MM-DD')
   }
 
   return agent
-    .get(`${apiBaseUrl}/rooms/nyc/meetings?start=${start}&end=${end}`).then((response) => {
-      const meetings = JSON.parse(response.text)
-      return meetings
-    })
-    .catch((err) => {
-      throw new Error(err)
-    })
+    .get(`${apiBaseUrl}/rooms/nyc/meetings?start=${start}&end=${end}`)
+    .set('x-access-token', token)
+    .then(response => response.body)
 }
 
-const createMeeting = (meeting, room, token) => agent
-  .post(`${apiBaseUrl}/room/${room.email}/meeting_protected`)
+const createMeeting = (token, meeting, room) => agent
+  .post(`${apiBaseUrl}/room/${room.email}/meeting`)
   .set('x-access-token', token)
   .send({
     title: meeting.title,
     start: meeting.start,
     end: meeting.end,
   })
-  .then(message => message)
+  .then(response => response.body)
 
-const cancelMeeting = (meetingId, roomEmail) => agent
+const cancelMeeting = (token, meetingId, roomEmail) => agent
   .delete(`${apiBaseUrl}/room/${roomEmail}/meeting/${meetingId}`)
   .then(message => message)
 

--- a/src/sagas/meetings.test.js
+++ b/src/sagas/meetings.test.js
@@ -1,4 +1,4 @@
-import { call, put } from 'redux-saga/effects'
+import { call, put, select } from 'redux-saga/effects'
 import { destroy } from 'redux-form'
 
 import api from '../api'
@@ -16,6 +16,8 @@ import {
   createMeeting,
 } from './meetings'
 
+import { getUserToken } from '../selectors'
+
 describe('Meetings Sagas', () => {
   const meeting = { room: 'Fuschia' }
   const room = 'bar'
@@ -25,7 +27,8 @@ describe('Meetings Sagas', () => {
     const meetings = [meeting]
     const generator = fetchMeetings()
 
-    expect(generator.next().value).toEqual(call(api.fetchMeetings, undefined, undefined))
+    expect(generator.next().value).toEqual(select(getUserToken))
+    expect(generator.next().value).toEqual(call(api.fetchMeetings, undefined, undefined, undefined))
     expect(generator.next(meetings).value)
       .toEqual(put(meetingsFetchSucceeded(meetings)))
     expect(generator.next().done).toBeTruthy()
@@ -40,10 +43,11 @@ describe('Meetings Sagas', () => {
   })
 
   it('creates meetings', () => {
-    const action = { payload: { meeting, room, token } }
+    const action = { payload: { meeting, room } }
     const generator = createMeeting(action)
 
-    expect(generator.next().value).toEqual(call(api.createMeeting, meeting, room, token))
+    expect(generator.next().value).toEqual(select(getUserToken))
+    expect(generator.next().value).toEqual(call(api.createMeeting, undefined, meeting, room))
     expect(generator.next().value).toEqual(put(closeMeetingDialog()))
     expect(generator.next().value).toEqual(put(destroy('meeting-editor')))
     expect(generator.next().value).toEqual(put(meetingCreateSucceeded()))

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,3 @@
+export const getUser = state => state.user
+
+export const getUserToken = state => getUser(state).token


### PR DESCRIPTION
Relates to [bookit-server PR #26: Meeting Visibility](https://github.com/buildit/bookit-server/pull/26).

All bookit-server endpoints that support the use of an auth token are now given said auth token via the `X-Access-Token` header on request.

The auth token is pulled from the user state object using the redux-saga `select` effect, passing a valid selector from the newly added `selectors.js` module.