### PR TITLE
Use our current Admin users in our faked admin checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ password: 'who da boss?'
 
 These credentials are [hardcoded into the server, along with a few other sample users](https://github.com/buildit/bookit-server/blob/master/src/service/stub/StubPasswordStore.ts).
 
+### Sample admin users
+roodmin@designitcontoso.onmicrosoft.com and rasmus@designitcontoso.onmicrosoft.com are both admin users. These users can see the Admin panel. All other users are forbidden from seeing this screen.
+
+Admin user authorization is currently stubbed out: see `src/lib/check-auth.js`.
+
 ## Design assets
 [Designs on Zeplin (must be granted access)](https://app.zeplin.io/project/58d4072283526a2ba8174a28)
 

--- a/src/lib/check-auth.js
+++ b/src/lib/check-auth.js
@@ -9,7 +9,11 @@ import { setClient } from '../actions'
  */
 
 const isUser = user => user.id && user.email && user.token
-const isAdmin = user => isUser(user) && (user.id === 1 || user.email === 'bruce@designitcontoso.onmicrosoft.com')
+const isAdmin = user => isUser(user) && (
+  user.email === 'rasmus@designitcontoso.onmicrosoft.com' ||
+  user.email === 'roodmin@designitcontoso.onmicrosoft.com' ||
+  user.id === 1
+)
 
 const checkStoredAuthorization = (dispatch, verifyUser) => {
   const storedUser = localStorage.getItem('user')


### PR DESCRIPTION
We are actually using two admin users: rasmus and roodmin. This commit
reflects current usage, which makes development a little easier.