### PR TITLE
unify sources of supported browsers

### DIFF
--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,2 +1,5 @@
-> 5%
-ie >= 11
+last 2 chrome versions
+last 2 firefox versions
+last 2 safari versions
+explorer >= 11
+edge > 0

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-preset-env": "^1.5.1",
     "babel-preset-react": "^6.24.1",
     "babili-webpack-plugin": "^0.1.1",
+    "browserslist": "^2.2.0",
     "clean-webpack-plugin": "^0.1.16",
     "coveralls": "^2.13.1",
     "css-loader": "^0.28.4",

--- a/webpack/parts/javascript.js
+++ b/webpack/parts/javascript.js
@@ -2,6 +2,10 @@ import { optimize } from 'webpack'
 
 import BabiliPlugin from 'babili-webpack-plugin'
 
+import browserslist from 'browserslist'
+
+const targetBrowsers = () => browserslist.readConfig('.browserlistrc').defaults
+
 const babeldev = () => ({
   loader: 'babel-loader',
   options: {
@@ -21,7 +25,7 @@ const babeldev = () => ({
       [
         'env', {
           targets: {
-            browsers: [ '> 5%', 'ie >= 11' ],
+            browsers: targetBrowsers(),
           },
           modules: false,
           useBuiltIns: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,6 +1318,13 @@ browserslist@^2.1.2, browserslist@^2.1.3:
     caniuse-lite "^1.0.30000670"
     electron-to-chromium "^1.3.11"
 
+browserslist@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.2.0.tgz#5e35ec993e467c6464b8cb708447386891de9f50"
+  dependencies:
+    caniuse-lite "^1.0.30000701"
+    electron-to-chromium "^1.3.15"
+
 bser@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
@@ -1429,6 +1436,10 @@ caniuse-db@^1.0.30000187, caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, ca
 caniuse-lite@^1.0.30000670:
   version "1.0.30000676"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000676.tgz#1e962123f48073f0c51c4ea0651dd64d25786498"
+
+caniuse-lite@^1.0.30000701:
+  version "1.0.30000704"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000704.tgz#adb6ea01134515663682db93abab291d4c02946b"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -2264,6 +2275,10 @@ ee-first@1.1.1:
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.11:
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz#1b3a5eace6e087bb5e257a100b0cbfe81b2891fc"
+
+electron-to-chromium@^1.3.15:
+  version "1.3.16"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz#d0e026735754770901ae301a21664cba45d92f7d"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This change will allow us to make "best effort" attempts to support all browser versions the client would like us to support, but beyond automatically polyfilling client-side javascript and post-fixing CSS at build-time, this offers no guarantees or tests for said supported browsers.

Improvements to the code were made to avoid repeating the supported browsers list in both `.browserslistrc` _and_ `webpack/parts/javascript.js` by making use of the actual `browserslist` node library (which was already installed as a dependency of some other library, but is now a clearly declared dev dependency of bookit-web).