### PR TITLE
Doesn't display edit button to user when already editing a meeting

### DIFF
--- a/src/components/01-atoms/Tooltip/TooltipContent.js
+++ b/src/components/01-atoms/Tooltip/TooltipContent.js
@@ -2,21 +2,23 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const TooltipContent =
-  ({ title, start, end, roomName, owner, isOwnedByUser, styles, onEditClick }) => (
-    <div className={styles.content}>
-      <div>
-        <strong className={styles.title}>{ title }</strong>
-        <p>{ start.format('h:mma') } - { end.format('h:mma') }</p>
-      </div>
-      <div className={styles.ownerInfo}>
+  ({ title, start, end, roomName, owner, isOwnedByUser, styles, onEditClick, isEditingMeeting }) => {
+    const isEditable = isOwnedByUser && !isEditingMeeting
+    return (
+      <div className={styles.content}>
         <div>
-          <strong className={styles.roomTitle}>{ roomName } Room</strong>
-          <p className="owner-name">by { isOwnedByUser ? 'me' : owner.name }</p>
+          <strong className={styles.title}>{ title }</strong>
+          <p>{ start.format('h:mma') } - { end.format('h:mma') }</p>
         </div>
-        {isOwnedByUser ? <div onClick={onEditClick} className={styles.edit}>Edit</div> : '' }
+        <div className={styles.ownerInfo}>
+          <div>
+            <strong className={styles.roomTitle}>{ roomName } Room</strong>
+            <p className="owner-name">by { isOwnedByUser ? 'me' : owner.name }</p>
+          </div>
+          {isEditable ? <div onClick={onEditClick} className={styles.edit}>Edit</div> : '' }
+        </div>
       </div>
-    </div>
-)
+    )}
 
 TooltipContent.propTypes = {
   title: PropTypes.string.isRequired,
@@ -29,6 +31,7 @@ TooltipContent.propTypes = {
   isOwnedByUser: PropTypes.bool.isRequired,
   styles: PropTypes.shape({}),
   onEditClick: PropTypes.func.isRequired,
+  isEditingMeeting: PropTypes.bool.isRequired,
 }
 
 export default TooltipContent

--- a/src/components/01-atoms/Tooltip/TooltipContent.test.js
+++ b/src/components/01-atoms/Tooltip/TooltipContent.test.js
@@ -15,6 +15,7 @@ describe('<TooltipContent />', () => {
       name: 'some guy',
     },
     isOwnedByUser: true,
+    isEditingMeeting: false,
     styles: {
       content: 'content',
       title: 'title',
@@ -52,5 +53,11 @@ describe('<TooltipContent />', () => {
     const propsCopy = { ...props, isOwnedByUser: true }
     const wrapper = shallow(<TooltipContent {...propsCopy} />)
     expect(wrapper.find('.edit').length).toBe(1)
+  })
+
+  it('does not show edit when user owns meeting, but is already editing a meeting', () => {
+    const propsCopy = { ...props, isOwnedByUser: true, isEditingMeeting: true }
+    const wrapper = shallow(<TooltipContent {...propsCopy} />)
+    expect(wrapper.find('.edit').length).toBe(0)
   })
 })

--- a/src/components/01-atoms/Tooltip/index.js
+++ b/src/components/01-atoms/Tooltip/index.js
@@ -20,6 +20,7 @@ const Tooltip = props => (
       isOwnedByUser={props.isOwnedByUser}
       styles={props.styles}
       onEditClick={props.onEditClick}
+      isEditingMeeting={props.isEditingMeeting}
     />
   </div>
 )
@@ -40,6 +41,7 @@ Tooltip.propTypes = {
     tooltip: PropTypes.string.isRequired,
   }).isRequired,
   onEditClick: PropTypes.func.isRequired,
+  isEditingMeeting: PropTypes.bool.isRequired,
 }
 
 export default Tooltip

--- a/src/components/01-atoms/Tooltip/index.test.js
+++ b/src/components/01-atoms/Tooltip/index.test.js
@@ -17,6 +17,7 @@ describe('<Tooltip />', () => {
       name: 'some guy',
     },
     isOwnedByUser: true,
+    isEditingMeeting: false,
     tooltipRef: () => true,
     anchorContainerRef: () => true,
     anchorRef: () => true,

--- a/src/components/02-molecules/Meeting/index.js
+++ b/src/components/02-molecules/Meeting/index.js
@@ -127,6 +127,7 @@ export class Meeting extends React.Component {
           anchorContainerRef={(el) => { this.$anchorContainer = el }}
           anchorRef={(el) => { this.$anchor = el }}
           styles={styles}
+          isEditingMeeting={this.props.isEditingMeeting}
           onEditClick={() => {
             onEditClick(meeting)
           }}
@@ -140,6 +141,7 @@ Meeting.propTypes = {
   meeting: PropTypes.shape({ isOwnedByUser: PropTypes.bool }).isRequired,
   onEditClick: PropTypes.func.isRequired,
   requestedMeetingId: PropTypes.string,
+  isEditingMeeting: PropTypes.bool.isRequired,
 }
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/02-molecules/Meeting/index.test.js
+++ b/src/components/02-molecules/Meeting/index.test.js
@@ -27,6 +27,7 @@ describe('<Meeting />', () => {
       isOwnedByUser: true,
     },
     onEditClick: jest.fn(),
+    isEditingMeeting: false,
     requestedMeetingId: 'xyz-123',
   }
 


### PR DESCRIPTION
This PR aims to resolve the bug in the meeting editor in which the form does not populate correctly when clicking on "edit" a second time (without closing the edit form). For now, we are hiding the "edit" button when "isEditingMeeting" is true.