### PR TITLE
Prevent src/functional-tests from being counted towards coverage

### DIFF
--- a/.jestrc.json
+++ b/.jestrc.json
@@ -13,7 +13,7 @@
     "!**/src/functional-tests/**"
   ],
   "coverageReporters": [
-    "text-summary",
+    "text",
     "lcov"
   ],
   "rootDir": ".",

--- a/.jestrc.json
+++ b/.jestrc.json
@@ -9,12 +9,12 @@
   "testEnvironment": "jsdom",
   "testRegex": "\\.test.js$",
   "collectCoverageFrom": [
-    "**/src/**/*.js"
+    "**/src/**/*.js",
+    "!**/src/functional-tests/**"
   ],
   "coverageReporters": [
-    "text",
-    "lcov",
-    "json"
+    "text-summary",
+    "lcov"
   ],
   "rootDir": ".",
   "globals": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 
 script:
   - yarn lint
-  - yarn test:unit
+  - yarn test:unit -- --colors --ci --silent
 
 after_success:
   - ./scripts/run-coveralls.sh


### PR DESCRIPTION
CAVEAT: There is no ticket for this, I am a jerk.

Hey! You want an instant percentage boost on coveralls? I know you do!

We are a little dumb and did not exclude src/functional-tests from jest's coverage collection.

I feel it's pretty fair that we don't want to include coverage of tests. Probably.

Also, as a bonus: travis now emits COLORS when running tests! It also suppresses console.log output from modules under test! IT'S AMAZING!