### PR TITLE
Block unwanted Timeline clicks

### DIFF
--- a/src/components/02-molecules/RoomTimeline/index.js
+++ b/src/components/02-molecules/RoomTimeline/index.js
@@ -17,7 +17,9 @@ class RoomTimeline extends React.Component {
   render() {
     const onTimelineClick = (e) => {
       const requestedStartTime = e.nativeEvent.offsetX / HOUR_WIDTH
-      this.props.populateMeetingCreateForm(this.props.room, requestedStartTime)
+      if (!this.props.meetingFormIsActive) {
+        this.props.populateMeetingCreateForm(this.props.room, requestedStartTime)
+      }
     }
 
     return (
@@ -52,6 +54,7 @@ RoomTimeline.propTypes = {
     roomId: PropTypes.string.isRequired,
   })).isRequired,
   populateMeetingCreateForm: PropTypes.func.isRequired,
+  meetingFormIsActive: PropTypes.bool.isRequired,
 }
 
 export default RoomTimeline

--- a/src/components/03-organisms/Agenda/index.js
+++ b/src/components/03-organisms/Agenda/index.js
@@ -11,7 +11,7 @@ import RoomTimeline from '../../02-molecules/RoomTimeline'
 
 import styles from './styles.scss'
 
-export const renderRoomTimelines = (rooms, meetings, populateMeetingCreateForm) => rooms.map(room => (
+export const renderRoomTimelines = (rooms, meetings, populateMeetingCreateForm, meetingFormIsActive) => rooms.map(room => (
   <RoomTimeline
     key={room.name}
     meetings={meetings.filter(meeting => meeting.roomId === room.id)}
@@ -20,17 +20,18 @@ export const renderRoomTimelines = (rooms, meetings, populateMeetingCreateForm) 
       name: room.name,
     }}
     populateMeetingCreateForm={populateMeetingCreateForm}
+    meetingFormIsActive={meetingFormIsActive}
   />
 ))
 
-const Agenda = ({ meetings, rooms, populateMeetingCreateForm }) => (
+const Agenda = ({ meetings, rooms, populateMeetingCreateForm, meetingFormIsActive }) => (
   <div className={styles.agenda}>
     <div className={styles.column}>
       { roomTimelineNames(rooms) }
     </div>
     <div className={[styles.column, styles.timeline].join(' ')} id="timelines">
       { timelineLabelList() }
-      { renderRoomTimelines(rooms, meetings, populateMeetingCreateForm) }
+      { renderRoomTimelines(rooms, meetings, populateMeetingCreateForm, meetingFormIsActive) }
       { currentTimeIndicator() }
     </div>
   </div>
@@ -60,6 +61,7 @@ Agenda.propTypes = {
       id: PropTypes.string.isRequired,
     }).isRequired
   ).isRequired,
+  meetingFormIsActive: PropTypes.bool.isRequired,
 }
 
 export default Agenda

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -44,6 +44,7 @@ export class DashboardContainer extends React.Component {
             meetings={meetings}
             rooms={rooms}
             populateMeetingCreateForm={this.props.populateMeetingCreateForm}
+            meetingFormIsActive={this.props.meetingFormIsActive}
           />
         </main>
       </div>
@@ -81,6 +82,8 @@ DashboardContainer.propTypes = {
     }).isRequired
   ).isRequired,
   location: PropTypes.shape({}),
+  isEditingMeeting: PropTypes.bool.isRequired,
+  meetingFormIsActive: PropTypes.bool.isRequired,
 }
 
 
@@ -110,6 +113,8 @@ const mapStateToProps = (state) => {
 
   const rooms = allRoomIds.map(id => roomsById[id])
 
+  const meetingFormIsActive = isEditingMeeting || isCreatingMeeting
+
   return ({
     user: state.user,
     meetings,
@@ -123,6 +128,7 @@ const mapStateToProps = (state) => {
     messages,
     selectedDate,
     requestedMeeting,
+    meetingFormIsActive,
   })
 }
 

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -87,23 +87,27 @@ const app = (state = initialState, action) => {
     }
   }
   case POPULATE_MEETING_CREATE_FORM: {
-    const meetings = state.allMeetingIds
-      .map(id => state.meetingsById[id])
-      .filter(meeting => meeting.roomId === action.payload.room.email)
+    const now = moment()
+    const startTime = state.selectedDate.clone().add(action.payload.meeting, 'hours')
+    const meetingCreationIsAllowed = startTime.isAfter(now)
 
-    // const meetings = Object.values(state.meetingsById)
-    //   .filter(meeting => meeting.roomId === action.payload.room.email)
-    const moment2 = state.selectedDate.clone().add(action.payload.meeting, 'hours')
-    const roundedDate = moment2.minutes(Math.floor(state.selectedDate.minutes() / 30) * 30)
-    const validatedSlot = getAvailableTimeSlot(roundedDate, meetings)
+    if (meetingCreationIsAllowed) {
+      const meetings = state.allMeetingIds
+        .map(id => state.meetingsById[id])
+        .filter(meeting => meeting.roomId === action.payload.room.email)
 
-    const meeting = {
-      title: '',
-      start: validatedSlot.start,
-      end: validatedSlot.end,
-      room: action.payload.room,
+      const roundedDate = startTime.minutes(Math.floor(state.selectedDate.minutes() / 30) * 30)
+      const validatedSlot = getAvailableTimeSlot(roundedDate, meetings)
+
+      const meeting = {
+        title: '',
+        start: validatedSlot.start,
+        end: validatedSlot.end,
+        room: action.payload.room,
+      }
+      return { ...state, isCreatingMeeting: true, requestedMeeting: meeting }
     }
-    return { ...state, isCreatingMeeting: true, requestedMeeting: meeting }
+    return state
   }
   case POPULATE_MEETING_EDIT_FORM: {
     const meeting = {


### PR DESCRIPTION
This commit prevents users from clicking the timeline in two cases when
we (probably) don't want them to do so:
- When edit form is open
- When they click on a time in the past

Addresses concerns related to [this issue](https://kanbanflow.com/t/5a7e8bd042bc161bd85acde29d3ad62b/8-open-assessment-bookit-button-is-enab)