### PR TITLE
Modify "Add user" functionality to match server

### DIFF
--- a/src/components/02-molecules/UserForm/index.js
+++ b/src/components/02-molecules/UserForm/index.js
@@ -10,32 +10,23 @@ const UserForm = ({
   user,
   handleSubmit,
   invalid,
- }) => {
-  const buttons = <Button disabled={invalid} type="submit" content="Invite" />
-
-  const header = <div className={styles.invite}>Invite Users</div>
-
-  return (
-    <div className={styles.form}>
-      { header }
-      <div className={styles.section}>Select a directory</div>
-      {// Right now the only directory we can add users from is Wipro.
-       // We may need to change this in the future
-      }
-      <div className={styles.teamSelector}>Wipro</div>
-      <div className={styles.section}>Enter user information</div>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault()
-          handleSubmit(user)
-        }}
-      >
-        <Field floatingLabelFixed floatingLabelText="E-mail address" name="email" component={TextField} />
-        { buttons }
-      </form>
-    </div>
-  )
-}
+ }) => (
+   <div className={styles.form}>
+     <div className={styles.invite}>Add Users</div>
+     <div className={styles.section}>Enter user information</div>
+     <form
+       onSubmit={(event) => {
+         event.preventDefault()
+         handleSubmit(user)
+       }}
+     >
+       <Field floatingLabelFixed
+         validate={value => value && !/@/.test(value) ? 'Invalid email address' : undefined}
+         floatingLabelText="E-mail address" name="email" component={TextField} />
+       <Button disabled={invalid} type="submit" content="Add user" />
+     </form>
+   </div>
+ )
 
 UserForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,

--- a/src/components/02-molecules/UserForm/styles.scss
+++ b/src/components/02-molecules/UserForm/styles.scss
@@ -14,12 +14,6 @@
   font-weight: 200;
 }
 
-.teamSelector{
-  font-size: 18px;
-  color: $veryyellow;
-  margin-top: 15px;
-}
-
 .form {
   width: 300px;
   float: left;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -161,7 +161,7 @@ const app = (state = initialState, action) => {
   case USER_INVITE_SUCCEEDED: {
     return {
       ...state,
-      messages: [`Welcome, ${action.payload.name}!`],
+      messages: [`Success! ${action.payload.name} has been added.`],
     }
   }
   case USER_INVITE_FAILED: {

--- a/src/reducers/users.js
+++ b/src/reducers/users.js
@@ -74,20 +74,8 @@ const fakeUsers = [
 const users = (state = fakeUsers, action) => {
   switch (action.type) {
   case USER_INVITE_SUCCEEDED: {
-    state.push({
-      name: action.payload.name,
-      // Hard coded for now. No use cases for other locations.
-      // We also need to figure out if we can get a notion of 'location'
-      // back from Azure
-      location: 'New York',
-      email: action.payload.email,
-      // Right now the only directory we can add users from is Wipro.
-      // We may need to change this in the future
-      team: 'WIPRO',
-      // Find out if Azure stores this info
-      dateAdded: moment(),
-    })
-    return state
+    const newUser = action.payload
+    return [...state, newUser]
   }
   case USER_REMOVE_SUCCEEDED: {
     const emailOfRemovedUser = action.payload

--- a/src/sagas/users.js
+++ b/src/sagas/users.js
@@ -16,7 +16,13 @@ export function* userInvite(action) {
 
   try {
     const apiUser = yield call(api.addUser, user)
-    yield put(userInviteSucceeded(apiUser))
+    const newUser = {
+      name: apiUser.name,
+      location: 'New York',
+      email: apiUser.email,
+      team: 'WIPRO',
+    }
+    yield put(userInviteSucceeded(newUser))
     yield put(closeInviteUserDialog())
   } catch (err) {
     yield put(userInviteFailed(err.message))


### PR DESCRIPTION
Resolves: https://kanbanflow.com/t/5a7e8bd042bc161bd85acde29d3e3f32/10-as-an-admin-i-want-to-add-invite-use

- Some small changes to what we send over the wire.

- Hardcode team (Wipro) and location (New York) for all added users. This happens in one spot on the client: `sagas/users.js`

- Email addresses must be valid (sort of) before the button is enabled.