### PR TITLE
43 admin navigation

### DIFF
--- a/src/components/02-molecules/ConditionalRouteLink/index.js
+++ b/src/components/02-molecules/ConditionalRouteLink/index.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Route } from 'react-router'
+
+import Link from '../../01-atoms/Link'
+
+export const ConditionalRouteLink = ({ path, to, ...props }) => (
+  <Route path={path} exact={true} children={({ match }) => ( // eslint-disable-line react/no-children-prop
+    (match && <Link to={to} {...props} />)
+  )}/>
+)
+
+ConditionalRouteLink.propTypes = {
+  path: PropTypes.string.isRequired,
+  to: Link.propTypes.to,
+}
+
+export default ConditionalRouteLink

--- a/src/components/02-molecules/ConditionalRouteLink/index.test.js
+++ b/src/components/02-molecules/ConditionalRouteLink/index.test.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import { MemoryRouter } from 'react-router'
+
+import Link from '../../01-atoms/Link'
+import ConditionalRouteLink from '.'
+
+describe('<ConditionalRouteLink />', () => {
+
+  const wrapper = mount(
+    <MemoryRouter
+      initialEntries={[ '/one', '/two', { pathname: '/three' } ]}
+      initialIndex={0}
+    >
+      <div>
+        <ConditionalRouteLink path="/one" to="/two">TWO</ConditionalRouteLink>
+        <ConditionalRouteLink path="/two" to="/three">THREE</ConditionalRouteLink>
+        <ConditionalRouteLink path="/three" to="/one">ONE</ConditionalRouteLink>
+      </div>
+    </MemoryRouter>
+  )
+
+  const { history } = wrapper.first(MemoryRouter).get(0)
+
+  const getActiveConditionalRouteLink = () => wrapper.find(ConditionalRouteLink).filterWhere(
+    n => n.prop('path') === history.location.pathname
+  ).first()
+
+  const getLinks = () => wrapper.find(Link)
+
+  it('renders just great', () => {
+    const conditionalRouteLinks = wrapper.find(ConditionalRouteLink)
+
+    expect(conditionalRouteLinks).toHaveLength(3)
+
+    expect(
+      conditionalRouteLinks.filterWhere(n => n.prop('path') === history.location.pathname)
+    ).toHaveLength(1)
+
+    expect(
+      conditionalRouteLinks.filterWhere(n => n.prop('path') !== history.location.pathname)
+    ).toHaveLength(2)
+  })
+
+  it(`renders a <Link /> for the current path "${history.location.pathname}"`, () => {
+    history.push('/one')
+
+    const links = getLinks()
+
+    expect(links).toHaveLength(1)
+    expect(links.first().prop('to')).toEqual(getActiveConditionalRouteLink().prop('to'))
+  })
+
+  it('renders the second <Link /> for the next path', () => {
+    const expected = { path: '/two', to: '/three', children: 'THREE' }
+
+    expect(getLinks().first().prop('to')).toEqual(expected.path)
+
+    history.push(getLinks().first().prop('to'))
+
+    const links = getLinks()
+
+    expect(links).toHaveLength(1)
+    expect(links.first().prop('to')).toEqual(expected.to)
+
+    expect(getActiveConditionalRouteLink().props()).toMatchObject(expected)
+  })
+
+})

--- a/src/components/02-molecules/Header/index.js
+++ b/src/components/02-molecules/Header/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Link from '../../01-atoms/Link'
+import ConditionalRouteLink from '../ConditionalRouteLink'
 
 import styles from './styles.scss'
 
@@ -11,7 +12,8 @@ const Header = ({ user, logout }) => (
     <span className={styles.name}>
       { user.name }!
     </span>
-    <Link to="/admin" className={styles.link}>Admin</Link>
+    <ConditionalRouteLink path="/" to="/admin" className={styles.link}>Manage Users</ConditionalRouteLink>
+    <ConditionalRouteLink path="/admin" to="/" className={styles.link}>Manage Rooms</ConditionalRouteLink>
     <Link to="/login" className={styles.link} onClick={logout}>Log Out</Link>
   </header>
 )

--- a/src/components/02-molecules/Header/index.js
+++ b/src/components/02-molecules/Header/index.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types'
 import Link from '../../01-atoms/Link'
 import ConditionalRouteLink from '../ConditionalRouteLink'
 
+import { isAdmin } from '../../../utils/check-auth'
+
 import styles from './styles.scss'
 
 const Header = ({ user, logout }) => (
@@ -12,7 +14,7 @@ const Header = ({ user, logout }) => (
     <span className={styles.name}>
       { user.name }!
     </span>
-    <ConditionalRouteLink path="/" to="/admin" className={styles.link}>Manage Users</ConditionalRouteLink>
+    { isAdmin(user) ? <ConditionalRouteLink path="/" to="/admin" className={styles.link}>Manage Users</ConditionalRouteLink> : '' }
     <ConditionalRouteLink path="/admin" to="/" className={styles.link}>Manage Rooms</ConditionalRouteLink>
     <Link to="/login" className={styles.link} onClick={logout}>Log Out</Link>
   </header>

--- a/src/components/02-molecules/Header/index.test.js
+++ b/src/components/02-molecules/Header/index.test.js
@@ -2,8 +2,13 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import Header from '.'
+import ConditionalRouteLink from '../ConditionalRouteLink'
+
+import { isAdmin } from '../../../utils/check-auth'
 
 import styles from './styles.scss'
+
+jest.mock('../../../utils/check-auth')
 
 describe('<Header />', () => {
   const props = {
@@ -14,5 +19,23 @@ describe('<Header />', () => {
   it('should welcome the user', () => {
     const wrapper = shallow(<Header {...props} />)
     expect(wrapper.find(`.${styles.name}`).text()).toBe(`${props.user.name}!`)
+  })
+
+  it('should show the Link to "Manage Users" if the user is an admin', () => {
+    isAdmin.mockImplementationOnce(() => true)
+
+    const wrapper = shallow(<Header {...props} />)
+
+    expect(wrapper.find(ConditionalRouteLink)).toHaveLength(2)
+    expect(wrapper.find(ConditionalRouteLink).filterWhere(n => n.prop('children') === 'Manage Users')).toHaveLength(1)
+  })
+
+  it('should NOT show the Link to "Manage Users" if the user is not admin', () => {
+    isAdmin.mockImplementationOnce(() => false)
+
+    const wrapper = shallow(<Header {...props} />)
+
+    expect(wrapper.find(ConditionalRouteLink)).toHaveLength(1)
+    expect(wrapper.find(ConditionalRouteLink).filterWhere(n => n.prop('children') === 'Manage Users')).toHaveLength(0)
   })
 })

--- a/src/utils/check-auth.js
+++ b/src/utils/check-auth.js
@@ -8,8 +8,8 @@ import { setClient } from '../actions'
  * It is entirely possible that I suck at branching logic
  */
 
-const isUser = user => user.email && user.token
-const isAdmin = user => isUser(user) && (user.email === 'bruce@builditcontoso.onmicrosoft.com')
+export const isUser = user => user.email && user.token
+export const isAdmin = user => isUser(user) && (user.email === 'bruce@builditcontoso.onmicrosoft.com')
 
 const checkStoredAuthorization = (dispatch, verifyUser) => {
   const storedUser = localStorage.getItem('user')


### PR DESCRIPTION
Ticket: https://kanbanflow.com/t/9218ae9d2bd4d7fe3dfb133bf27e5871/43-as-an-admin-i-want-to-access-the-us

Ensures that the (admin) user sees the correct links in the header to navigate between the users and timeline pages.

This PR introduces a new `ConditionalRouteLink` component, which is essentially a `Route` component (from react-router) that wraps a `Link` component.

The idea is that since you can use `Route` components anywhere inside an app, you can use its own functionality to decide if the `children` props will get rendered based on the `match` property that the route resolves from the parent `Router`.

Currently a `ConditionalRouteLink` will render only when the `path` prop _exactly_ matches the current `history.location.pathname` value.

The `match` prop will either be `null` if the path did not match, or it will be the full react-router match object, filled with all sorts of delicious matching-related goodness that we don't care about.