### PR TITLE
50 in progress rules

### DIFF
--- a/src/components/01-atoms/Tooltip/TooltipContent.js
+++ b/src/components/01-atoms/Tooltip/TooltipContent.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import moment from 'moment'
 
 const TooltipContent =
   ({ title, start, end, roomName, owner, isOwnedByUser, styles, onEditClick, isEditingMeeting }) => {
-    const isEditable = isOwnedByUser && !isEditingMeeting
+    const now = moment()
+    const isEditable = isOwnedByUser && !isEditingMeeting && end.isAfter(now)
     return (
       <div className={styles.content}>
         <div>

--- a/src/components/01-atoms/Tooltip/TooltipContent.test.js
+++ b/src/components/01-atoms/Tooltip/TooltipContent.test.js
@@ -9,7 +9,7 @@ describe('<TooltipContent />', () => {
   const props = {
     title: 'A Meeting',
     start: moment(),
-    end: moment(),
+    end: moment().add(1, 'hour'),
     roomName: 'roomy mcroomface',
     owner: {
       name: 'some guy',
@@ -49,10 +49,16 @@ describe('<TooltipContent />', () => {
     expect(wrapper.find('.edit').length).toBe(0)
   })
 
-  it('shows edit when owned by user', () => {
+  it('shows edit when owned by user and end is not in the past', () => {
     const propsCopy = { ...props, isOwnedByUser: true }
     const wrapper = shallow(<TooltipContent {...propsCopy} />)
     expect(wrapper.find('.edit').length).toBe(1)
+  })
+
+  it('does not show edit when the end of the meeting is in the past', () => {
+    const propsCopy = { ...props, isOwnedByUser: true, start: moment().subtract(2, 'hours'), end: moment().subtract(1, 'hour') }
+    const wrapper = shallow(<TooltipContent {...propsCopy} />)
+    expect(wrapper.find('.edit').length).toBe(0)
   })
 
   it('does not show edit when user owns meeting, but is already editing a meeting', () => {

--- a/src/components/02-molecules/DateTimePicker/index.js
+++ b/src/components/02-molecules/DateTimePicker/index.js
@@ -8,7 +8,7 @@ import styles from './styles.scss'
 
 injectTapEventPlugin()
 
-const DateTimePicker = ({ name, label, error }) => {
+const DateTimePicker = ({ name, label, disabled, error }) => {
   const datePickerStyle = { display: 'inline-block' }
   const datePickerTextFieldStyle = { width: '150px', fontSize: '18px', fontWeight: '100' }
   const timePickerStyle = datePickerStyle
@@ -18,6 +18,7 @@ const DateTimePicker = ({ name, label, error }) => {
     <div className={styles.dateTimePicker} >
       <Field
         name={name}
+        disabled={disabled}
         floatingLabelText={label}
         component={DatePicker}
         autoOk
@@ -28,6 +29,7 @@ const DateTimePicker = ({ name, label, error }) => {
       />
       <Field
         name={name}
+        disabled={disabled}
         autoOk
         component={TimePicker}
         floatingLabelText=" " /* Need this to keep lines aligned :/  */
@@ -41,6 +43,7 @@ const DateTimePicker = ({ name, label, error }) => {
 DateTimePicker.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
+  disabled: PropTypes.bool,
   error: PropTypes.string,
 }
 

--- a/src/components/02-molecules/MeetingForm/index.js
+++ b/src/components/02-molecules/MeetingForm/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import moment from 'moment'
 
 import { Field } from 'redux-form'
 import { TextField } from 'redux-form-material-ui'
@@ -23,10 +24,15 @@ const MeetingForm = ({
   validationErrors = {},
   visibleErrorMessages,
   isCreatingMeeting,
+  isEditingMeeting,
   handleDeleteClick,
   handleSaveClick,
  }) => {
+  const now = moment()
+  const meetingStart = moment(meeting.start)
+
   const isSubmitDisabled = invalid || hasValidationErrors(validationErrors)
+  const isStartDisabled = isEditingMeeting && meetingStart.isBefore(now)
 
   const buttons = isCreatingMeeting
     ? <Button disabled={isSubmitDisabled} type="submit" content="Bookit" />
@@ -49,7 +55,7 @@ const MeetingForm = ({
         }}
       >
         <Field floatingLabelFixed floatingLabelText="Event name" name="title" component={TextField} errorText={errors.title} style={meetingTitleStyle} />
-        <DateTimePicker locale="en-US" name="start" label="Start" />
+        <DateTimePicker name="start" label="Start" disabled={isStartDisabled} />
         <DateTimePicker name="end" label="End" />
         { buttons }
         <ErrorMessages messages={validationErrors} allowableMessages={visibleErrorMessages} />
@@ -78,6 +84,7 @@ MeetingForm.propTypes = {
   handleDeleteClick: PropTypes.func.isRequired,
   handleSaveClick: PropTypes.func.isRequired,
   isCreatingMeeting: PropTypes.bool.isRequired,
+  isEditingMeeting: PropTypes.bool.isRequired,
 }
 
 export default MeetingForm

--- a/src/components/02-molecules/ReservationList/ReservationItem.js
+++ b/src/components/02-molecules/ReservationList/ReservationItem.js
@@ -1,9 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import moment from 'moment'
 
 import MomentPropTypes from 'react-moment-proptypes'
 
-const ReservationItem = ({ styles, meeting, onClick }) => (
+const ReservationItem = ({ styles, meeting, onClick }) => {
+  const now = moment()
+  const isEditable = meeting.end.isAfter(now)
+  return (
   <div className={styles.meeting}>
     <div className={styles.info}>
       <div className={styles.title}>
@@ -17,9 +21,9 @@ const ReservationItem = ({ styles, meeting, onClick }) => (
       </div>
     </div>
     {/* THIS SHOULD BE A Button COMPONENT! */}
-    <div onClick={onClick} className={styles.button}>Edit</div>
+    {isEditable ? <div onClick={onClick} className={styles.button}>Edit</div> : ''}
   </div>
-)
+  )}
 
 ReservationItem.propTypes = {
   styles: PropTypes.object,

--- a/src/components/02-molecules/ReservationList/ReservationItem.test.js
+++ b/src/components/02-molecules/ReservationList/ReservationItem.test.js
@@ -29,4 +29,31 @@ describe('<ReservationItem />', () => {
     const wrapper = shallow(<ReservationItem {...props} />)
     expect(wrapper).toBeTruthy()
   })
+
+  it('displays the title', () => {
+    const wrapper = shallow(<ReservationItem {...props} />)
+    expect(wrapper.find('.title').text()).toBe('A Meeting')
+  })
+
+  it('displays the time in the proper format', () => {
+    const propsCopy = { ...props, meeting: {start: moment('Fri Aug 04 2017 14:51:34'), end: moment('Fri Aug 04 2017 15:51:34')} }
+    const wrapper = shallow(<ReservationItem {...propsCopy} />)
+    expect(wrapper.find('.time').text()).toBe('2:51pm - 3:51pm')
+  })
+
+  it('displays the room name', () => {
+    const wrapper = shallow(<ReservationItem {...props} />)
+    expect(wrapper.find('.room').text()).toBe('roomy mcroomface Room')
+  })
+
+  it('does not allow the user to edit if the meeting is over', () => {
+    const propsCopy = { ...props, meeting: {start: moment().subtract(3, 'hours'), end: moment().subtract(1, 'hour')} }
+    const wrapper = shallow(<ReservationItem {...propsCopy} />)
+    expect(wrapper.find('.button').length).toBe(0)
+  })
+
+  it('displays an edit button if the meeting is in the future', () => {
+    const wrapper = shallow(<ReservationItem {...props} />)
+    expect(wrapper.find('.button').length).toBe(1)
+  })
 })

--- a/src/containers/MeetingForm/index.js
+++ b/src/containers/MeetingForm/index.js
@@ -18,17 +18,17 @@ const validate = (values) => {
   const now = moment()
 
   const errors = {}
-
   if (startMom.isAfter(endMom)) {
     errors.end = 'The start time must be before the end time'
   }
 
-  //allow users to edit existing meetings by checking for id
+  //start time can't be before now if it is a new meeting, but existing
+  //meetings with a start time in the past can be edited
   if (startMom.isBefore(now) && !values.id) {
     errors.noTimeTravel = 'You can\'t book in the past'
   }
 
-  //disallow changing the end time to a time in the past
+  //disallow changing the end time of an existing meeting to a time in the past
   if (values.id && endMom.isBefore(now)) {
     errors.noTimeTravel = 'You can\'t book in the past'
   }

--- a/src/containers/MeetingForm/index.js
+++ b/src/containers/MeetingForm/index.js
@@ -13,7 +13,6 @@ import {
  } from '../../actions/index'
 
 const validate = (values) => {
-  console.log(values)
   const startMom = moment(values.start)
   const endMom = moment(values.end)
   const now = moment()
@@ -24,7 +23,13 @@ const validate = (values) => {
     errors.end = 'The start time must be before the end time'
   }
 
-  if (startMom.isBefore(now)) {
+  //allow users to edit existing meetings by checking for id
+  if (startMom.isBefore(now) && !values.id) {
+    errors.noTimeTravel = 'You can\'t book in the past'
+  }
+
+  //disallow changing the end time to a time in the past
+  if (values.id && endMom.isBefore(now)) {
     errors.noTimeTravel = 'You can\'t book in the past'
   }
 
@@ -72,8 +77,9 @@ const mapStateToProps = state => ({
   roomId: state.app.requestedMeeting.roomId,
   initialValues: mapFormValues(state.app.requestedMeeting),
   validationErrors: state.form && state.form['meeting-form'] && state.form['meeting-form'].syncErrors,
-  visibleErrorMessages: ['noTimeTravel', 'end', 'upperBound'],
+  visibleErrorMessages: ['noTimeTravel', 'end', 'upperBound', 'title'],
   isCreatingMeeting: state.app.isCreatingMeeting,
+  isEditingMeeting: state.app.isEditingMeeting,
 })
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
This branch handles allowing users to edit meetings in various states.

The `edit` button is obscured for meetings that have already ended (`end` time is in the past), both on the tooltip and in the reservation list.

Meetings that are in progress can be edited, but only the end time can be changed (a user can't move the start time farther into the past). This is handled by disabling the date/time picker for the meeting start.

The user cannot submit an edit if the new start or end time is in the past.