### PR TITLE
[OOB] Remove unnecessary console.log from webpack config

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -4,8 +4,6 @@ import merge from 'webpack-merge'
 
 import parts from './webpack/parts'
 
-console.log('LIFECYCLE EVENT:', process.env.npm_lifecycle_event)
-
 if (process.env.WDS_HOST === undefined) process.env.WDS_HOST = 'localhost'
 if (process.env.WDS_PORT === undefined) process.env.WDS_PORT = 3001
 


### PR DESCRIPTION
remove console.log from webpack config as it can mess with various stats-related tools output.

To be honest, it should have never been in there - it was a vestigial leftover from where I was debugging the crap out of running webpack with webpack-merge. It just stuck around because it never really caused a problem (until I tried to run an analysis on overall size of the production build, where the log statement was getting injected into the output file of the stats used for analysis).