### PR TITLE
70 date time picker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
 
 install:
   - if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then pip install awscli; fi
+  - yarn
 
 before_script:
   # Builds only when branch is master and this is NOT a PR

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "query-string": "^4.3.4",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-kronos": "^1.6.0",
     "react-redux": "^5.0.5",
     "react-router-redux": "next",
     "react-tap-event-plugin": "^2.0.1",

--- a/src/components/02-molecules/DateTimePicker/index.js
+++ b/src/components/02-molecules/DateTimePicker/index.js
@@ -30,30 +30,38 @@ const DateTimePicker = (field) => {
     marginBottom: '20px',
   }
 
+  const calendarStyle = {
+    backgroundColor: '#2b3947',
+    color: 'white',
+  }
+
+
+
   return (
     <div className={styles.dateTimePicker} >
     <Kronos
       date={field.input.value}
       format="dddd, MMMM Do, YYYY"
-      min={moment()}
+      min={moment().startOf('day')}
       onChangeDateTime={result => field.input.onChange(result)}
-      preventClickOnDateTimeOutsideRange={true}
+      preventClickOnDateTimeOutsideRange
       inputStyle={dateStyle}
-      hideOutsideDateTimes={true}
+      hideOutsideDateTimes
+      calendarStyle={calendarStyle}
       options={{
         font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
         corners: '0',
       }}
     />
     <Kronos
-      name={name}
       time={field.input.value}
       format="h:mm a"
+      min={moment().startOf('minute')}
       onChangeDateTime={result => field.input.onChange(result)}
-      preventClickOnDateTimeOutsideRange={true}
+      preventClickOnDateTimeOutsideRange
       inputStyle={timeStyle}
       timeStep={15}
-      hideOutsideDateTimes={true}
+      hideOutsideDateTimes
       options={{
         format: {hour: 'h:mm a'},
         font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',

--- a/src/components/02-molecules/DateTimePicker/index.js
+++ b/src/components/02-molecules/DateTimePicker/index.js
@@ -32,10 +32,13 @@ const DateTimePicker = (field) => {
 
   const calendarStyle = {
     backgroundColor: '#2b3947',
-    color: 'white',
+    width: '245px',
   }
 
-
+  const dropdownStyle = {
+    backgroundColor: '#2b3947',
+    padding: '0',
+  }
 
   return (
     <div className={styles.dateTimePicker} >
@@ -51,6 +54,7 @@ const DateTimePicker = (field) => {
       options={{
         font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
         corners: '0',
+        locale: 'en-us',
       }}
     />
     <Kronos
@@ -62,6 +66,7 @@ const DateTimePicker = (field) => {
       inputStyle={timeStyle}
       timeStep={15}
       hideOutsideDateTimes
+      calendarStyle={dropdownStyle}
       options={{
         format: {hour: 'h:mm a'},
         font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',

--- a/src/components/02-molecules/DateTimePicker/index.js
+++ b/src/components/02-molecules/DateTimePicker/index.js
@@ -1,50 +1,67 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { Field } from 'redux-form'
-import { DatePicker, TimePicker } from 'redux-form-material-ui'
-import injectTapEventPlugin from 'react-tap-event-plugin'
 import styles from './styles.scss'
+import Kronos from 'react-kronos'
+import moment from 'moment'
 
-injectTapEventPlugin()
-
-const DateTimePicker = ({ name, label, disabled, error }) => {
-  const datePickerStyle = { display: 'inline-block' }
-  const datePickerTextFieldStyle = { width: '150px', fontSize: '18px', fontWeight: '100' }
-  const timePickerStyle = datePickerStyle
-  const timePickerTextFieldStyle = { width: '68px', fontSize: '18px', fontWeight: '100' }
+const DateTimePicker = ({ name, meeting }) => {
+  const dateStyle = {
+    width: '245px',
+    border: 'none',
+    backgroundColor: '#141516',
+    borderBottom: '1px solid #fbfe34',
+    fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
+    borderRadius: '0',
+    padding: '0',
+    marginBottom: '20px',
+    marginLeft: '0',
+  }
+  const timeStyle = {
+    width: '75px',
+    border: 'none',
+    backgroundColor: '#141516',
+    borderBottom: '1px solid #fbfe34',
+    fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
+    borderRadius: '0',
+    padding: '0',
+    marginBottom: '20px',
+  }
 
   return (
     <div className={styles.dateTimePicker} >
-      <Field
-        name={name}
-        disabled={disabled}
-        floatingLabelText={label}
-        component={DatePicker}
-        autoOk
-        errorText={error}
-        style={datePickerStyle}
-        textFieldStyle={datePickerTextFieldStyle}
-        formatDate={new Intl.DateTimeFormat('en-US', { weekday: 'short', day: 'numeric', month: 'long', year: 'numeric' }).format}
-      />
-      <Field
-        name={name}
-        disabled={disabled}
-        autoOk
-        component={TimePicker}
-        floatingLabelText=" " /* Need this to keep lines aligned :/  */
-        style={timePickerStyle}
-        textFieldStyle={timePickerTextFieldStyle}
-      />
+    <Kronos
+      name={name}
+      date={name === "start" ? moment(meeting.start) : moment(meeting.end) }
+      format="dddd, MMMM Do, YYYY"
+      min={moment()}
+      onChange={this.onChange}
+      preventClickOnDateTimeOutsideRange={true}
+      inputStyle={dateStyle}
+      hideOutsideDateTimes={true}
+    />
+    <Kronos
+      name={name}
+      time={name === "start" ? moment(meeting.start) : moment(meeting.end) }
+      format="h:mm a"
+      minTime={moment()}
+      onChange={this.onChange}
+      preventClickOnDateTimeOutsideRange={true}
+      inputStyle={timeStyle}
+      timeStep={15}
+      hideOutsideDateTimes={true}
+      options={{
+        format: {hour: 'h:mm a'},
+      }}
+    />
     </div>
   )
 }
 
 DateTimePicker.propTypes = {
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   label: PropTypes.string,
-  disabled: PropTypes.bool,
-  error: PropTypes.string,
+  meeting: PropTypes.shape({}),
 }
 
 export default DateTimePicker

--- a/src/components/02-molecules/DateTimePicker/index.js
+++ b/src/components/02-molecules/DateTimePicker/index.js
@@ -1,52 +1,52 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-
-import styles from './styles.scss'
 import Kronos from 'react-kronos'
 import moment from 'moment'
 
-const DateTimePicker = (field) => {
-  const dateStyle = {
-    width: '245px',
-    border: 'none',
-    backgroundColor: '#141516',
-    color: 'white',
-    borderBottom: '1px solid #fbfe34',
-    fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
-    borderRadius: '0',
-    padding: '0',
-    marginBottom: '20px',
-    marginLeft: '0',
-  }
-  const timeStyle = {
-    width: '75px',
-    border: 'none',
-    backgroundColor: '#141516',
-    color: 'white',
-    borderBottom: '1px solid #fbfe34',
-    fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
-    borderRadius: '0',
-    padding: '0',
-    marginBottom: '20px',
-  }
+// NOTE: See `src/index.ejs` for additional styles that are applied to this component, specifically the datepicker calendar and timepicker dropdown.
+// Global styles are bad -- we know! -- but this seemed to be the only way to override the styles defined by the React-Kronos library.
+// The author of React-Kronos seems to acknowledge this liability: https://github.com/dubert/react-kronos/blob/master/README.md#roadmap
 
-  // NOTE: Other styles are being applied to the datepicker calendar and timepicker dropdown
-  // by overriding the React-Kronos library's styles. This is happening in bookit's index.ejs.
-  // This was the only way to make this component match the designs.
-  const calendarStyle = {
-    backgroundColor: '#2b3947',
-    // TODO: figure out how to center the calendar when the width is increased
-    // probably via "grid" and "cell" width
-    // width: '245px',
-  }
+const DateTimePickerStyle = {
+  display: 'flex',
+  justifyContent: 'space-between',
+}
 
-  const dropdownStyle = {
-    backgroundColor: '#2b3947',
-    padding: '0',
-  }
+const dateStyle = {
+  width: '245px',
+  border: 'none',
+  backgroundColor: '#141516',
+  color: 'white',
+  borderBottom: '1px solid #fbfe34',
+  fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
+  borderRadius: '0',
+  padding: '0',
+  marginBottom: '20px',
+  marginLeft: '0',
+}
 
-  return (
-    <div className={styles.dateTimePicker} >
+const timeStyle = {
+  width: '75px',
+  border: 'none',
+  backgroundColor: '#141516',
+  color: 'white',
+  borderBottom: '1px solid #fbfe34',
+  fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
+  borderRadius: '0',
+  padding: '0',
+  marginBottom: '20px',
+}
+
+const calendarStyle = {
+  backgroundColor: '#2b3947',
+}
+
+const dropdownStyle = {
+  backgroundColor: '#2b3947',
+  padding: '0',
+}
+
+const DateTimePicker = field => (
+  <div style={DateTimePickerStyle} >
     <Kronos
       date={field.input.value}
       format="dddd, MMMM Do, YYYY"
@@ -58,8 +58,8 @@ const DateTimePicker = (field) => {
       calendarStyle={calendarStyle}
       options={{
         font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
-        corners: '0',
-        locale: 'en-us',
+        corners: 0,
+        locale: { lang: 'en-us' },
       }}
     />
     <Kronos
@@ -73,19 +73,12 @@ const DateTimePicker = (field) => {
       hideOutsideDateTimes
       calendarStyle={dropdownStyle}
       options={{
-        format: {hour: 'h:mm a'},
+        format: { hour: 'h:mm a' },
         font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
-        corners: '0',
+        corners: 0,
       }}
     />
-    </div>
-  )
-}
-
-DateTimePicker.propTypes = {
-  name: PropTypes.string,
-  label: PropTypes.string,
-  meeting: PropTypes.shape({}),
-}
+  </div>
+)
 
 export default DateTimePicker

--- a/src/components/02-molecules/DateTimePicker/index.js
+++ b/src/components/02-molecules/DateTimePicker/index.js
@@ -5,11 +5,12 @@ import styles from './styles.scss'
 import Kronos from 'react-kronos'
 import moment from 'moment'
 
-const DateTimePicker = ({ name, meeting }) => {
+const DateTimePicker = (field) => {
   const dateStyle = {
     width: '245px',
     border: 'none',
     backgroundColor: '#141516',
+    color: 'white',
     borderBottom: '1px solid #fbfe34',
     fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
     borderRadius: '0',
@@ -21,6 +22,7 @@ const DateTimePicker = ({ name, meeting }) => {
     width: '75px',
     border: 'none',
     backgroundColor: '#141516',
+    color: 'white',
     borderBottom: '1px solid #fbfe34',
     fontFamily: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
     borderRadius: '0',
@@ -31,27 +33,31 @@ const DateTimePicker = ({ name, meeting }) => {
   return (
     <div className={styles.dateTimePicker} >
     <Kronos
-      name={name}
-      date={name === "start" ? moment(meeting.start) : moment(meeting.end) }
+      date={field.input.value}
       format="dddd, MMMM Do, YYYY"
       min={moment()}
-      onChange={this.onChange}
+      onChangeDateTime={result => field.input.onChange(result)}
       preventClickOnDateTimeOutsideRange={true}
       inputStyle={dateStyle}
       hideOutsideDateTimes={true}
+      options={{
+        font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
+        corners: '0',
+      }}
     />
     <Kronos
       name={name}
-      time={name === "start" ? moment(meeting.start) : moment(meeting.end) }
+      time={field.input.value}
       format="h:mm a"
-      minTime={moment()}
-      onChange={this.onChange}
+      onChangeDateTime={result => field.input.onChange(result)}
       preventClickOnDateTimeOutsideRange={true}
       inputStyle={timeStyle}
       timeStep={15}
       hideOutsideDateTimes={true}
       options={{
         format: {hour: 'h:mm a'},
+        font: 'HelveticaNeue, Roboto, Helvetica, sans-serif',
+        corners: '0',
       }}
     />
     </div>

--- a/src/components/02-molecules/DateTimePicker/index.js
+++ b/src/components/02-molecules/DateTimePicker/index.js
@@ -30,9 +30,14 @@ const DateTimePicker = (field) => {
     marginBottom: '20px',
   }
 
+  // NOTE: Other styles are being applied to the datepicker calendar and timepicker dropdown
+  // by overriding the React-Kronos library's styles. This is happening in bookit's index.ejs.
+  // This was the only way to make this component match the designs.
   const calendarStyle = {
     backgroundColor: '#2b3947',
-    width: '245px',
+    // TODO: figure out how to center the calendar when the width is increased
+    // probably via "grid" and "cell" width
+    // width: '245px',
   }
 
   const dropdownStyle = {

--- a/src/components/02-molecules/DateTimePicker/styles.scss
+++ b/src/components/02-molecules/DateTimePicker/styles.scss
@@ -1,4 +1,0 @@
-.dateTimePicker {
-  display: flex;
-  justify-content: space-between;
-}

--- a/src/components/02-molecules/MeetingForm/index.js
+++ b/src/components/02-molecules/MeetingForm/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import moment from 'moment'
 
 import { Field } from 'redux-form'
 import { TextField } from 'redux-form-material-ui'
@@ -10,7 +9,7 @@ import ErrorMessages from '../ErrorMessages'
 import styles from './styles.scss'
 
 
-const meetingTitleStyle = { fontSize: '18px', fontWeight: '100' }
+const meetingTitleStyle = { fontSize: '18px', fontWeight: '100', marginBottom: '15px' }
 const hasValidationErrors = errors => Object.keys(errors).length > 0
 
 const MeetingForm = ({
@@ -24,15 +23,11 @@ const MeetingForm = ({
   validationErrors = {},
   visibleErrorMessages,
   isCreatingMeeting,
-  isEditingMeeting,
   handleDeleteClick,
   handleSaveClick,
  }) => {
-  const now = moment()
-  const meetingStart = moment(meeting.start)
 
   const isSubmitDisabled = invalid || hasValidationErrors(validationErrors)
-  const isStartDisabled = isEditingMeeting && meetingStart.isBefore(now)
 
   const buttons = isCreatingMeeting
     ? <Button disabled={isSubmitDisabled} type="submit" content="Bookit" />
@@ -55,8 +50,8 @@ const MeetingForm = ({
         }}
       >
         <Field floatingLabelFixed floatingLabelText="Event name" name="title" component={TextField} errorText={errors.title} style={meetingTitleStyle} />
-        <DateTimePicker name="start" label="Start" disabled={isStartDisabled} />
-        <DateTimePicker name="end" label="End" />
+        <DateTimePicker name="start" meeting={meeting} />
+        <DateTimePicker name="end" meeting={meeting} />
         { buttons }
         <ErrorMessages messages={validationErrors} allowableMessages={visibleErrorMessages} />
       </form>
@@ -84,7 +79,6 @@ MeetingForm.propTypes = {
   handleDeleteClick: PropTypes.func.isRequired,
   handleSaveClick: PropTypes.func.isRequired,
   isCreatingMeeting: PropTypes.bool.isRequired,
-  isEditingMeeting: PropTypes.bool.isRequired,
 }
 
 export default MeetingForm

--- a/src/components/02-molecules/MeetingForm/index.js
+++ b/src/components/02-molecules/MeetingForm/index.js
@@ -50,8 +50,8 @@ const MeetingForm = ({
         }}
       >
         <Field floatingLabelFixed floatingLabelText="Event name" name="title" component={TextField} errorText={errors.title} style={meetingTitleStyle} />
-        <DateTimePicker name="start" meeting={meeting} />
-        <DateTimePicker name="end" meeting={meeting} />
+        <Field name="start" component={DateTimePicker} />
+        <Field name="end" component={DateTimePicker} />
         { buttons }
         <ErrorMessages messages={validationErrors} allowableMessages={visibleErrorMessages} />
       </form>

--- a/src/containers/MeetingForm/index.js
+++ b/src/containers/MeetingForm/index.js
@@ -49,12 +49,13 @@ const MeetingFormContainer = reduxForm({
   validate,
 })(MeetingForm)
 
-const mapFormValues = values => ({
-  id: values.id,
-  title: values.title,
-  start: values.start && moment(values.start).toDate(),
-  end: values.end && moment(values.end).toDate(),
-})
+const mapFormValues = (values) => {
+  console.log('im in the meeting form container', values)
+  return ({id: values.id,
+    title: values.title,
+    start: values.start && moment(values.start).toDate(),
+    end: values.end && moment(values.end).toDate()})
+}
 
 const getSubmittableMeeting = (form, meeting) => {
   // FIXME: This is crazy-sauce. What is the right way?

--- a/src/containers/MeetingForm/index.js
+++ b/src/containers/MeetingForm/index.js
@@ -50,7 +50,6 @@ const MeetingFormContainer = reduxForm({
 })(MeetingForm)
 
 const mapFormValues = (values) => {
-  console.log('im in the meeting form container', values)
   return ({id: values.id,
     title: values.title,
     start: values.start && moment(values.start).toDate(),

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -10,7 +10,59 @@
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css">
     <title>Bookit</title>
   </head>
-
+  <style type = "text/css">
+    .grid {
+      width: 231px !important;
+    }
+    .title {
+      font-weight: 400 !important;
+      color: white !important;
+      font-size: 14px !important;
+    }
+    .title:hover {
+      border: 1px solid #2b3947 !important;
+    }
+    .arrow {
+      color: #fbfe34 !important;
+    }
+    .header {
+      color: #d0d0d0 !important;
+      font-weight: 400 !important;
+    }
+    .cell {
+      width: 36px !important;
+    }
+    .cell:hover {
+      background-color: yellow !important;
+    }
+    .hours {
+      font-size: 12px !important;
+      font-weight: 100 !important;
+    }
+    .days {
+      font-weight: 100 !important;
+      font-size: 12px !important;
+    }
+    .selected {
+      background-color: #141516 !important;
+      border: 1px solid #141516 !important;
+    }
+    .arrow:hover {
+      border: 1px solid #2b3947 !important;
+    }
+    .base {
+      color: white !important;
+    }
+    .outside-range {
+      color: #696969 !important;
+    }
+    .outside-range:hover {
+      background-color: #2b3947 !important;
+    }
+    .past {
+      color: #d0d0d0 !important;
+    }
+  </style>
   <body>
     <div id="root"></div>
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -11,9 +11,17 @@
     <title>Bookit</title>
   </head>
   <style type = "text/css">
+/* NOTE: These are overrides for the React-Kronos datepicker calendar and timepicker dropdown
+  Other styles are also being applied to the DateTimePicker in DateTimePicker/index.js */
+/* WARNING(?): If we ever move away from the "styles.<name>" pattern in the rest of our CSS, it might cause
+    collisions with these changes. */
+
+/* REACT-KRONOS DATETIMEPICKER OVERRIDES */
+    /*dropdown list (time picker) */
     .grid {
       width: 231px !important;
     }
+    /*month name */
     .title {
       font-weight: 400 !important;
       color: white !important;
@@ -22,43 +30,45 @@
     .title:hover {
       border: 1px solid #2b3947 !important;
     }
+    /*month rockers*/
     .arrow {
       color: #fbfe34 !important;
-    }
-    .header {
-      color: #d0d0d0 !important;
-      font-weight: 400 !important;
-    }
-    .cell {
-      width: 36px !important;
-    }
-    .cell:hover {
-      background-color: yellow !important;
-    }
-    .hours {
-      font-size: 12px !important;
-      font-weight: 100 !important;
-    }
-    .days {
-      font-weight: 100 !important;
-      font-size: 12px !important;
-    }
-    .selected {
-      background-color: #141516 !important;
-      border: 1px solid #141516 !important;
     }
     .arrow:hover {
       border: 1px solid #2b3947 !important;
     }
+    /*day names (M T W Th... etc)*/
+    .header {
+      color: #d0d0d0 !important;
+      font-weight: 400 !important;
+    }
+    /*hours in time picker dropdown list*/
+    .hours {
+      font-size: 12px !important;
+      font-weight: 100 !important;
+    }
+    /*dates in calendar*/
+    .days {
+      font-weight: 100 !important;
+      font-size: 12px !important;
+    }
+    /*selected date on calendar*/
+    .selected {
+      background-color: #141516 !important;
+      border: 1px solid #141516 !important;
+    }
+    /*base class for dates in calendar*/
     .base {
       color: white !important;
     }
+    /*dates outside bookable range*/
     .outside-range {
       color: #696969 !important;
     }
     .outside-range:hover {
       background-color: #2b3947 !important;
     }
+    /*dates in the past*/
     .past {
       color: #d0d0d0 !important;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,6 +1531,10 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.3.tgz#07cfe8980edb20d455ddc23aadcf1e04c6e509ce"
@@ -1624,7 +1628,7 @@ color-string@^0.3.0:
   dependencies:
     color-name "^1.0.0"
 
-color@^0.11.0:
+color@^0.11.0, color@^0.11.4:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
   dependencies:
@@ -1932,6 +1936,12 @@ css-tokenize@^1.0.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^1.0.33"
+
+css-vendor@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
+  dependencies:
+    is-in-browser "^1.0.2"
 
 css-what@2.1:
   version "2.1.0"
@@ -3570,6 +3580,10 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-in-browser@1.0.2, is-in-browser@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.0.2.tgz#f688bea8f1e5aadc3244ebc870d188cfb9b613cf"
+
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
@@ -4107,6 +4121,71 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+jss-camel-case@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-3.0.0.tgz#46aa18eb149e95afce074532ad47df1c2a7d45cb"
+
+jss-compose@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-2.1.0.tgz#3751d613fb61c715e3d91140dea5f1794968847d"
+  dependencies:
+    warning "^3.0.0"
+
+jss-default-unit@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-5.0.3.tgz#b9450f31c37feaed3151554b2938363974780af1"
+
+jss-expand@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-2.1.0.tgz#dc0f458304a9f597b524dd4ae773ea29adcb3d27"
+
+jss-extend@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-3.0.1.tgz#aeb5846f1650d7590c686b5c1932b44a3721742d"
+  dependencies:
+    warning "^3.0.0"
+
+jss-global@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-0.4.1.tgz#41862c78528de4d333853004eb71adecde1a5fda"
+
+jss-nested@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-3.0.1.tgz#14c10265c8fc5bd61b450b48f1e9fb36d90ae569"
+  dependencies:
+    warning "^3.0.0"
+
+jss-preset-default@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-1.3.1.tgz#8a4b7f9a41ec412d19fb1d23e6dc80ebef040d5a"
+  dependencies:
+    jss-camel-case "^3.0.0"
+    jss-compose "^2.0.0"
+    jss-default-unit "^5.0.2"
+    jss-expand "^2.0.3"
+    jss-extend "^3.0.0"
+    jss-global "^0.4.1"
+    jss-nested "^3.0.1"
+    jss-props-sort "^3.0.0"
+    jss-vendor-prefixer "^4.0.0"
+
+jss-props-sort@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-3.0.0.tgz#19544610109b1fa953f22799eecb080240d8dc00"
+
+jss-vendor-prefixer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-4.0.0.tgz#df16a8fcc6ecb4567394174e6ab90145cf8b34a3"
+  dependencies:
+    css-vendor "^0.3.8"
+
+jss@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-6.5.0.tgz#9294a367b658daa2036c36f563ff6bfb0c7b12a1"
+  dependencies:
+    is-in-browser "1.0.2"
+    warning "3.0.0"
+
 jsx-ast-utils@^1.3.4, jsx-ast-utils@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
@@ -4542,7 +4621,11 @@ moment-duration-format@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-1.3.0.tgz#541771b5f87a049cc65540475d3ad966737d6908"
 
-moment@>=1.6.0, moment@^2.10.3, moment@^2.14.1, moment@^2.18.1:
+moment-range@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/moment-range/-/moment-range-2.2.0.tgz#b02575778a4ac50a65777939f5c5d757f83fcd85"
+
+moment@>=1.6.0, moment@^2.10.3, moment@^2.14.1, moment@^2.18.0, moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
@@ -5628,6 +5711,18 @@ react-hot-loader@next:
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
     source-map "^0.4.4"
+
+react-kronos@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/react-kronos/-/react-kronos-1.6.0.tgz#2213a223fcaeaf04dfbe27e7524c68197c212bf7"
+  dependencies:
+    classnames "^2.2.5"
+    color "^0.11.4"
+    jss "^6.5.0"
+    jss-preset-default "^1.3.1"
+    lodash "^4.17.4"
+    moment "^2.18.0"
+    moment-range "^2.2.0"
 
 react-moment-proptypes@^1.4.0:
   version "1.4.0"
@@ -7219,7 +7314,7 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^3.0.0:
+warning@3.0.0, warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   dependencies:


### PR DESCRIPTION
This PR replaces the `material-ui` date and time picker with `React-Kronos.`

As of now, all of the meeting form's validations/behavior remain the same, but Kronos allows for us to:
- customize the date/time formats
- prevent the user from clicking on dates in the past
- prevent display of times in the past
- customize the meeting time intervals

This is much more user-friendly and less confusing.

The date and time `input` fields in Kronos are easily customized via the component's props. Unfortunately, some hacky CSS magic in the `index.ejs` was required to make the datepicker's calendar and timepicker's dropdown look consistent with the designs for Bookit.